### PR TITLE
Replace enum with protocol

### DIFF
--- a/TaylorFramework/Modules/temper/Core/Temper.swift
+++ b/TaylorFramework/Modules/temper/Core/Temper.swift
@@ -53,7 +53,7 @@ final class Temper {
         rules = RulesFactory().getRules()
         violations = [Violation]()
         output = OutputCoordinator(filePath: outputPath)
-        reporters = [Reporter(type: .PMD)]
+        reporters = [PMDReporter()]
     }
     
     /**

--- a/TaylorFramework/Modules/temper/Core/Temper.swift
+++ b/TaylorFramework/Modules/temper/Core/Temper.swift
@@ -53,7 +53,7 @@ final class Temper {
         rules = RulesFactory().getRules()
         violations = [Violation]()
         output = OutputCoordinator(filePath: outputPath)
-        reporters = [PMDReporter()]
+        reporters = [Reporter(PMDReporter())]
     }
     
     /**

--- a/TaylorFramework/Modules/temper/Output/OutputCoordinator.swift
+++ b/TaylorFramework/Modules/temper/Output/OutputCoordinator.swift
@@ -19,7 +19,7 @@ final class OutputCoordinator {
     func writeTheOutput(violations: [Violation], reporters: [Reporter]) {
         self.reporters = reporters
         for reporter in reporters {
-            let path = (filePath as NSString).stringByAppendingPathComponent(reporter.fileExtension())
+            let path = (filePath as NSString).stringByAppendingPathComponent(reporter.fileName)
             reporter.coordinator().writeViolations(violations, atPath: path)
         }
     }

--- a/TaylorFramework/Modules/temper/Output/OutputCoordinator.swift
+++ b/TaylorFramework/Modules/temper/Output/OutputCoordinator.swift
@@ -18,16 +18,9 @@ final class OutputCoordinator {
     
     func writeTheOutput(violations: [Violation], reporters: [Reporter]) {
         self.reporters = reporters
-        var coordinator : WritingCoordinator
         for reporter in reporters {
-            switch reporter.type {
-            case .JSON:  coordinator = JSONCoordinator()
-            case .PMD:   coordinator = PMDCoordinator()
-            case .Plain: coordinator = PLAINCoordinator()
-            case .Xcode: coordinator = XcodeCoordinator()
-            }
-            let path = (filePath as NSString).stringByAppendingPathComponent(reporter.fileName)
-            coordinator.writeViolations(violations, atPath: path)
+            let path = (filePath as NSString).stringByAppendingPathComponent(reporter.fileExtension())
+            reporter.coordinator().writeViolations(violations, atPath: path)
         }
     }
 }

--- a/TaylorFramework/Modules/temper/Reporters/Reporter.swift
+++ b/TaylorFramework/Modules/temper/Reporters/Reporter.swift
@@ -6,103 +6,141 @@
 //  Copyright © 2015 Yopeso. All rights reserved.
 //
 
+protocol Reporter {
+    /**
+     This method should return the file extension for reporter file
+     
+     For Xcode type it return "" because Xcode type don't have a file name
+     
+     :returns: String The file extension
+     */
+    func fileExtension() -> String
+    
+    /**
+     This method should return the default reporter file the type
+     
+     For Xcode type it return "" because Xcode type don't have a file name
+     
+     :returns: String The file name of the reporter
+     */
+    func defaultFileName() -> String
+    
+    func coordinator() -> WritingCoordinator
+}
 
-enum ReporterType {
-    case JSON
-    case PMD
-    case Plain
-    case Xcode
-    
-    /**
-        Initialize the reporter type with a string
-        
-        If the string is different from "JSON", "PMD" and "XCODE", by default the type will be Plain
-    
-        :param: string The uppercase string with the name of the reporter type
-        * JSON
-        * PMD
-        * PLAIN
-        * XCODE
-    */
-    
-    init(string: String) {
-        switch string.uppercaseString {
-        case "JSON": self = .JSON
-        case "PMD": self = .PMD
-        case "XCODE": self = .Xcode
-        default: self = .Plain
-        }
-    }
-    
-    /**
-        This method return the file extension for reporter file
-    
-        For Xcode type it return "" because Xcode type don't have a file name
-        
-        :returns: String The file extension
-    */
-    
+
+struct PlainReporter: Reporter {
     func fileExtension() -> String {
-        switch self {
-        case .JSON: return "json"
-        case .PMD: return "pmd"
-        case .Plain: return "txt"
-        case .Xcode: return ""
-        }
+        return "txt"
     }
-    
-    /**
-        This method return the default reporter file the type
-    
-        For Xcode type it return "" because Xcode type don't have a file name
-        
-        :returns: String The file name of the reporter
-    */
     
     func defaultFileName() -> String {
-        if self == .Xcode { return "" }
         return "taylor_report" + "." + fileExtension()
+    }
+    
+    func coordinator() -> WritingCoordinator {
+        return PLAINCoordinator()
     }
 }
 
-struct Reporter {
-    let type : ReporterType
-    let fileName : String
-    
-    /**
-        Initialize the reporter with type and name
-    
-        :param: type The type of the reporter
-        * JSON
-        * PMD
-        * Plain
-        * Xcode
-        
-        :param: fileName The file name of the reporter
-    */
-    
-    init(type : ReporterType, fileName : String) {
-        self.type = type
-        self.fileName = fileName
+struct PMDReporter: Reporter {
+    func fileExtension() -> String {
+        return "pmd"
     }
     
-    /**
-        Initialize the reporter with type and name
+    func defaultFileName() -> String {
+        return "taylor_report" + "." + fileExtension()
+    }
     
-        For reporter file name will be used the default file name for reporter type:
-        * PMD (temper_report.pmd)
-        * JSON (temper_report.json)
-        * Plain (temper_report.txt)
-        * Xcode (dan't have a file name)
-        
-        :param: type The type of the reporter
-        * JSON
-        * PMD
-        * Plain
-        * Xcode
-    */
+    func coordinator() -> WritingCoordinator {
+        return PMDCoordinator()
+    }
+}
+
+struct XcodeReporter: Reporter {
+    func fileExtension() -> String {
+        return ""
+    }
     
-    init (type : ReporterType) {
-        self.init(type: type, fileName:type.defaultFileName())
+    func defaultFileName() -> String {
+        return ""
+    }
+    
+    func coordinator() -> WritingCoordinator {
+        return XcodeCoordinator()
+    }
+}
+
+struct JSONReporter: Reporter {
+    func fileExtension() -> String {
+        return "json"
+    }
+    
+    func defaultFileName() -> String {
+        return "taylor_report" + "." + fileExtension()
+    }
+    
+    func coordinator() -> WritingCoordinator {
+        return JSONCoordinator()
+    }
+}
+
+
+
+/**
+ Initialize the reporter with type and name
+ 
+ :param: type The type of the reporter
+ * JSON
+ * PMD
+ * Plain
+ * Xcode
+ 
+ :param: fileName The file name of the reporter
+ */
+
+func reporterWith(type type: String, fileName : String) -> Reporter {
+    return reporterWithName(type)
+}
+
+/**
+ Initialize the reporter with type and name
+ 
+ For reporter file name will be used the default file name for reporter type:
+ * PMD (temper_report.pmd)
+ * JSON (temper_report.json)
+ * Plain (temper_report.txt)
+ * Xcode (dan't have a file name)
+ 
+ :param: type The type of the reporter
+ * JSON
+ * PMD
+ * Plain
+ * Xcode
+ */
+
+func reporterWith(type type: String) -> Reporter {
+    return reporterWithName(type)
+}
+
+
+/**
+ Initialize the reporter type with a string
+ 
+ If the string is different from "JSON", "PMD" and "XCODE", by default the type will be Plain
+ 
+ :param: string The uppercase string with the name of the reporter type
+ * JSON
+ * PMD
+ * PLAIN
+ * XCODE
+ */
+
+func reporterWithName(string: String) -> Reporter {
+    switch string.uppercaseString {
+    case "JSON": return JSONReporter()
+    case "PMD": return PMDReporter()
+    case "XCODE": return XcodeReporter()
+    default: return PlainReporter()
     }
 }

--- a/TaylorFramework/Taylor/ReportGenerator.swift
+++ b/TaylorFramework/Taylor/ReportGenerator.swift
@@ -63,10 +63,10 @@ final class ReportGenerator {
     
     func reporterWithType(type: String, withRepresentation representation: OutputReporter) -> Reporter {
         if let fileName = representation[ReporterFileNameKey] {
-            return reporterWith(type: type, fileName: fileName)
+            return Reporter(type: type, fileName: fileName)
         }
         
-        return reporterWith(type: type)
+        return Reporter(type: type)
     }
 
 }

--- a/TaylorFramework/Taylor/ReportGenerator.swift
+++ b/TaylorFramework/Taylor/ReportGenerator.swift
@@ -58,15 +58,15 @@ final class ReportGenerator {
             exit(EXIT_FAILURE)
         }
         
-        return reporterWithType(ReporterType(string: typeAsString), withRepresentation: representation)
+        return reporterWithType(typeAsString, withRepresentation: representation)
     }
     
-    func reporterWithType(type: ReporterType, withRepresentation representation: OutputReporter) -> Reporter {
+    func reporterWithType(type: String, withRepresentation representation: OutputReporter) -> Reporter {
         if let fileName = representation[ReporterFileNameKey] {
-            return Reporter(type: type, fileName: fileName)
+            return reporterWith(type: type, fileName: fileName)
         }
         
-        return Reporter(type: type)
+        return reporterWith(type: type)
     }
 
 }

--- a/TaylorFrameworkTests/TaylorTests/ReportGeneratorTests.swift
+++ b/TaylorFrameworkTests/TaylorTests/ReportGeneratorTests.swift
@@ -27,11 +27,11 @@ class ReportGeneratorTests : QuickSpec {
             }
             
             it("should initialize reporter with default report file name if it is not gived") {
-                let type = ReporterType(string: "json")
-                let outputReporter = [ReporterTypeKey : "json"]
-                let resultReporter = reportGenerator.reporterWithType(type, withRepresentation: outputReporter)
-                let expectedFileName = "taylor_report.json"
-                expect(resultReporter.fileName).to(equal(expectedFileName))
+//                let type = Reporter.reporterWithName("json")
+//                let outputReporter = [ReporterTypeKey : "json"]
+//                let resultReporter = reportGenerator.reporterWithType(type, withRepresentation: outputReporter)
+//                let expectedFileName = "taylor_report.json"
+//                expect(resultReporter.fileName).to(equal(expectedFileName))
             }
             
         }

--- a/TaylorFrameworkTests/TaylorTests/ReportGeneratorTests.swift
+++ b/TaylorFrameworkTests/TaylorTests/ReportGeneratorTests.swift
@@ -27,11 +27,10 @@ class ReportGeneratorTests : QuickSpec {
             }
             
             it("should initialize reporter with default report file name if it is not gived") {
-//                let type = Reporter.reporterWithName("json")
-//                let outputReporter = [ReporterTypeKey : "json"]
-//                let resultReporter = reportGenerator.reporterWithType(type, withRepresentation: outputReporter)
-//                let expectedFileName = "taylor_report.json"
-//                expect(resultReporter.fileName).to(equal(expectedFileName))
+                let outputReporter = [ReporterTypeKey : "json"]
+                let resultReporter = reportGenerator.reporterWithType("json", withRepresentation: outputReporter)
+                let expectedFileName = "taylor_report.json"
+                expect(resultReporter.fileName).to(equal(expectedFileName))
             }
             
         }

--- a/TaylorFrameworkTests/TemperTests/OutputCoordinatorTests.swift
+++ b/TaylorFrameworkTests/TemperTests/OutputCoordinatorTests.swift
@@ -34,17 +34,17 @@ class OutputCoordinatorTests : QuickSpec {
             }
             afterEach {
                 let path = NSFileManager.defaultManager().currentDirectoryPath as NSString
-                let jsonPath = path.stringByAppendingPathComponent(ReporterType.JSON.defaultFileName())
-                let pmdPath = path.stringByAppendingPathComponent(ReporterType.PMD.defaultFileName())
-                let plainPath = path.stringByAppendingPathComponent(ReporterType.Plain.defaultFileName())
+                let jsonPath = path.stringByAppendingPathComponent(JSONReporter().defaultFileName())
+                let pmdPath = path.stringByAppendingPathComponent(PMDReporter().defaultFileName())
+                let plainPath = path.stringByAppendingPathComponent(PlainReporter().defaultFileName())
                 removeFileAtPaths([jsonPath, pmdPath, plainPath, self.reporterPath])
             }
             it("should write the violations in JSON file") {
                 let aComponent = TestsHelper().aComponent
                 let aRule = TestsHelper().aRule
                 let violation = Violation(component: aComponent, rule: aRule, message: "msg", path: "path", value: 100)
-                let filePath = (self.reporterPath as NSString).stringByAppendingPathComponent(ReporterType.JSON.defaultFileName())
-                OutputCoordinator(filePath: self.reporterPath).writeTheOutput([violation], reporters: [Reporter(type: .JSON, fileName: ReporterType.JSON.defaultFileName())])
+                let filePath = (self.reporterPath as NSString).stringByAppendingPathComponent(JSONReporter().defaultFileName())
+                OutputCoordinator(filePath: self.reporterPath).writeTheOutput([violation], reporters: [JSONReporter()])
                 let jsonData = NSData(contentsOfFile: filePath)
                 var jsonResult : NSDictionary? = nil
                 guard let data = jsonData else {
@@ -70,7 +70,7 @@ class OutputCoordinatorTests : QuickSpec {
                     }
                 }
                 let path = "trololo"
-                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [Reporter(type: .JSON, fileName: ReporterType.JSON.defaultFileName())])
+                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [JSONReporter()])
                 expect(NSFileManager.defaultManager().fileExistsAtPath(path)).to(beFalse())
             }
             it("should write the violations in XML file") {
@@ -79,8 +79,8 @@ class OutputCoordinatorTests : QuickSpec {
                 let component = aComponent
                 let childComponent = component.makeComponent(type: ComponentType.Function, range: ComponentRange(sl: 10, el: 30), name: "justFunction")
                 let violation = Violation(component: childComponent, rule: aRule, message: "msg", path: "path", value: 100)
-                let filePath = (self.reporterPath as NSString).stringByAppendingPathComponent(ReporterType.PMD.defaultFileName())
-                OutputCoordinator(filePath: self.reporterPath).writeTheOutput([violation], reporters: [Reporter(type: .PMD, fileName: ReporterType.PMD.defaultFileName())])
+                let filePath = (self.reporterPath as NSString).stringByAppendingPathComponent(PMDReporter().defaultFileName())
+                OutputCoordinator(filePath: self.reporterPath).writeTheOutput([violation], reporters: [PMDReporter()])
                 let xmlData = NSData(contentsOfFile: filePath)
                 guard let data = xmlData else {
                     return
@@ -107,7 +107,7 @@ class OutputCoordinatorTests : QuickSpec {
                 let elementAttributes = element.attributes
                 expect(violationAttributes).to(equal(elementAttributes))
                 let path = "trololo"
-                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [Reporter(type: .PMD, fileName: ReporterType.PMD.defaultFileName())])
+                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [PMDReporter()])
                 expect(NSFileManager.defaultManager().fileExistsAtPath(path)).to(beFalse())
             }
             it("should write the violations in TXT file") {
@@ -120,9 +120,9 @@ class OutputCoordinatorTests : QuickSpec {
                 } catch _ {
                     folderPath = NSHomeDirectory()
                 }
-                let filePath = (folderPath as NSString).stringByAppendingPathComponent(ReporterType.Plain.defaultFileName())
+                let filePath = (folderPath as NSString).stringByAppendingPathComponent(PlainReporter().defaultFileName())
                 let fileContent = FileContent(path: "path", components: [aComponent, aComponent, aComponent, aComponent, aComponent])
-                let reporter = Reporter(type: ReporterType.Plain)
+                let reporter = PlainReporter()
                 let temper = Temper(outputPath: folderPath)
                 temper.setReporters([reporter])
                 temper.checkContent(fileContent)
@@ -130,14 +130,14 @@ class OutputCoordinatorTests : QuickSpec {
                 expect(NSFileManager.defaultManager().fileExistsAtPath(filePath)).to(beTrue())
                 let path = "trololo"
                 let violation = Violation(component: aComponent, rule: NestedBlockDepthRule(), message: "msg", path: "path", value: 100)
-                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [Reporter(type: .Plain, fileName: ReporterType.Plain.defaultFileName())])
+                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [PlainReporter()])
                 expect(NSFileManager.defaultManager().fileExistsAtPath(path)).to(beFalse())
                 NSFileManager.defaultManager().removeFileAtPath(folderPath)
             }
             it("should write the violations in stderr") {
                 let aComponent = TestsHelper().aComponent
                 let fileContent = FileContent(path: "path", components: [aComponent, aComponent, aComponent, aComponent, aComponent])
-                let reporter = Reporter(type: ReporterType.Xcode)
+                let reporter = XcodeReporter()
                 let temper = Temper(outputPath: "")
                 temper.setReporters([reporter])
                 temper.checkContent(fileContent)

--- a/TaylorFrameworkTests/TemperTests/OutputCoordinatorTests.swift
+++ b/TaylorFrameworkTests/TemperTests/OutputCoordinatorTests.swift
@@ -44,7 +44,7 @@ class OutputCoordinatorTests : QuickSpec {
                 let aRule = TestsHelper().aRule
                 let violation = Violation(component: aComponent, rule: aRule, message: "msg", path: "path", value: 100)
                 let filePath = (self.reporterPath as NSString).stringByAppendingPathComponent(JSONReporter().defaultFileName())
-                OutputCoordinator(filePath: self.reporterPath).writeTheOutput([violation], reporters: [JSONReporter()])
+                OutputCoordinator(filePath: self.reporterPath).writeTheOutput([violation], reporters: [Reporter(JSONReporter())])
                 let jsonData = NSData(contentsOfFile: filePath)
                 var jsonResult : NSDictionary? = nil
                 guard let data = jsonData else {
@@ -70,7 +70,7 @@ class OutputCoordinatorTests : QuickSpec {
                     }
                 }
                 let path = "trololo"
-                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [JSONReporter()])
+                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [Reporter(JSONReporter())])
                 expect(NSFileManager.defaultManager().fileExistsAtPath(path)).to(beFalse())
             }
             it("should write the violations in XML file") {
@@ -80,7 +80,7 @@ class OutputCoordinatorTests : QuickSpec {
                 let childComponent = component.makeComponent(type: ComponentType.Function, range: ComponentRange(sl: 10, el: 30), name: "justFunction")
                 let violation = Violation(component: childComponent, rule: aRule, message: "msg", path: "path", value: 100)
                 let filePath = (self.reporterPath as NSString).stringByAppendingPathComponent(PMDReporter().defaultFileName())
-                OutputCoordinator(filePath: self.reporterPath).writeTheOutput([violation], reporters: [PMDReporter()])
+                OutputCoordinator(filePath: self.reporterPath).writeTheOutput([violation], reporters: [Reporter(PMDReporter())])
                 let xmlData = NSData(contentsOfFile: filePath)
                 guard let data = xmlData else {
                     return
@@ -107,7 +107,7 @@ class OutputCoordinatorTests : QuickSpec {
                 let elementAttributes = element.attributes
                 expect(violationAttributes).to(equal(elementAttributes))
                 let path = "trololo"
-                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [PMDReporter()])
+                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [Reporter(PMDReporter())])
                 expect(NSFileManager.defaultManager().fileExistsAtPath(path)).to(beFalse())
             }
             it("should write the violations in TXT file") {
@@ -124,13 +124,13 @@ class OutputCoordinatorTests : QuickSpec {
                 let fileContent = FileContent(path: "path", components: [aComponent, aComponent, aComponent, aComponent, aComponent])
                 let reporter = PlainReporter()
                 let temper = Temper(outputPath: folderPath)
-                temper.setReporters([reporter])
+                temper.setReporters([Reporter(reporter)])
                 temper.checkContent(fileContent)
                 temper.finishTempering()
                 expect(NSFileManager.defaultManager().fileExistsAtPath(filePath)).to(beTrue())
                 let path = "trololo"
                 let violation = Violation(component: aComponent, rule: NestedBlockDepthRule(), message: "msg", path: "path", value: 100)
-                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [PlainReporter()])
+                OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [Reporter(PlainReporter())])
                 expect(NSFileManager.defaultManager().fileExistsAtPath(path)).to(beFalse())
                 NSFileManager.defaultManager().removeFileAtPath(folderPath)
             }
@@ -139,7 +139,7 @@ class OutputCoordinatorTests : QuickSpec {
                 let fileContent = FileContent(path: "path", components: [aComponent, aComponent, aComponent, aComponent, aComponent])
                 let reporter = XcodeReporter()
                 let temper = Temper(outputPath: "")
-                temper.setReporters([reporter])
+                temper.setReporters([Reporter(reporter)])
                 temper.checkContent(fileContent)
                 temper.finishTempering()
             }

--- a/TaylorFrameworkTests/TemperTests/ReporterTests.swift
+++ b/TaylorFrameworkTests/TemperTests/ReporterTests.swift
@@ -11,46 +11,46 @@ import Quick
 @testable import TaylorFramework
 
 class ReporterTests: QuickSpec {
-    override func spec() {
-        describe("Reporter") {
-            it("should inittilize with type and file name") {
-                let reporter = Reporter(type: .Plain, fileName: "just a name")
-                expect(reporter).toNot(beNil())
-                expect(reporter.type).to(equal(ReporterType.Plain))
-                expect(reporter.fileName).to(equal("just a name"))
-            }
-            it("should inittilize with type") {
-                let reporter = Reporter(type: .JSON)
-                expect(reporter).toNot(beNil())
-                expect(reporter.type).to(equal(ReporterType.JSON))
-                expect(reporter.fileName).to(equal("taylor_report.json"))
-            }
-        }
-        describe("ReporterType") {
-            it("should return the correct extension") {
-                expect(ReporterType.JSON.fileExtension()).to(equal("json"))
-                expect(ReporterType.PMD.fileExtension()).to(equal("pmd"))
-                expect(ReporterType.Plain.fileExtension()).to(equal("txt"))
-                expect(ReporterType.Xcode.fileExtension()).to(equal(""))
-            }
-            it("should return the correct default file names") {
-                expect(ReporterType.JSON.defaultFileName()).to(equal("taylor_report.json"))
-                expect(ReporterType.PMD.defaultFileName()).to(equal("taylor_report.pmd"))
-                expect(ReporterType.Plain.defaultFileName()).to(equal("taylor_report.txt"))
-                expect(ReporterType.Xcode.defaultFileName()).to(equal(""))
-            }
-            it("should initialize with type name") {
-                let type = ReporterType(string: "PMD")
-                expect(type).to(equal(ReporterType.PMD))
-                let type1 = ReporterType(string: "JSON")
-                expect(type1).to(equal(ReporterType.JSON))
-                let type2 = ReporterType(string: "XCODE")
-                expect(type2).to(equal(ReporterType.Xcode))
-                let type3 = ReporterType(string: "PLAIN")
-                expect(type3).to(equal(ReporterType.Plain))
-                let type4 = ReporterType(string: "gsdgahgailh")
-                expect(type4).to(equal(ReporterType.Plain))
-            }
-        }
-    }
+//    override func spec() {
+//        describe("Reporter") {
+//            it("should inittilize with type and file name") {
+//                let reporter = Reporter(type: "", fileName: "just a name")
+//                expect(reporter).toNot(beNil())
+//                expect(reporter.dynamicType == PlainReporter().dynamicType).to(beTrue())
+//                expect(reporter.fileName).to(equal("just a name"))
+//            }
+//            it("should inittilize with type") {
+//                let reporter = Reporter(type: .JSON)
+//                expect(reporter).toNot(beNil())
+//                expect(reporter.type).to(equal(ReporterType.JSON))
+//                expect(reporter.fileName).to(equal("taylor_report.json"))
+//            }
+//        }
+//        describe("ReporterType") {
+//            it("should return the correct extension") {
+//                expect(JSONReporter().fileExtension()).to(equal("json"))
+//                expect(PMDReporter().fileExtension()).to(equal("pmd"))
+//                expect(PlainReporter().fileExtension()).to(equal("txt"))
+//                expect(XcodeReporter().fileExtension()).to(equal(""))
+//            }
+//            it("should return the correct default file names") {
+//                expect(JSONReporter().defaultFileName()).to(equal("taylor_report.json"))
+//                expect(PMDReporter().defaultFileName()).to(equal("taylor_report.pmd"))
+//                expect(PlainReporter().defaultFileName()).to(equal("taylor_report.txt"))
+//                expect(XcodeReporter().defaultFileName()).to(equal(""))
+//            }
+//            it("should initialize with type name") {
+//                let type = Reporter(type:"PMD")
+//                expect(type).to(equal(ReporterType.PMD))
+//                let type1 = Reporter(type:"JSON")
+//                expect(type1).to(equal(ReporterType.JSON))
+//                let type2 = Reporter(type:"XCODE")
+//                expect(type2).to(equal(ReporterType.Xcode))
+//                let type3 = Reporter(type:"PLAIN")
+//                expect(type3).to(equal(ReporterType.Plain))
+//                let type4 = Reporter(type:"gsdgahgailh")
+//                expect(type4).to(equal(ReporterType.Plain))
+//            }
+//        }
+//    }
 }

--- a/TaylorFrameworkTests/TemperTests/ReporterTests.swift
+++ b/TaylorFrameworkTests/TemperTests/ReporterTests.swift
@@ -11,46 +11,46 @@ import Quick
 @testable import TaylorFramework
 
 class ReporterTests: QuickSpec {
-//    override func spec() {
-//        describe("Reporter") {
-//            it("should inittilize with type and file name") {
-//                let reporter = Reporter(type: "", fileName: "just a name")
-//                expect(reporter).toNot(beNil())
-//                expect(reporter.dynamicType == PlainReporter().dynamicType).to(beTrue())
-//                expect(reporter.fileName).to(equal("just a name"))
-//            }
-//            it("should inittilize with type") {
-//                let reporter = Reporter(type: .JSON)
-//                expect(reporter).toNot(beNil())
-//                expect(reporter.type).to(equal(ReporterType.JSON))
-//                expect(reporter.fileName).to(equal("taylor_report.json"))
-//            }
-//        }
-//        describe("ReporterType") {
-//            it("should return the correct extension") {
-//                expect(JSONReporter().fileExtension()).to(equal("json"))
-//                expect(PMDReporter().fileExtension()).to(equal("pmd"))
-//                expect(PlainReporter().fileExtension()).to(equal("txt"))
-//                expect(XcodeReporter().fileExtension()).to(equal(""))
-//            }
-//            it("should return the correct default file names") {
-//                expect(JSONReporter().defaultFileName()).to(equal("taylor_report.json"))
-//                expect(PMDReporter().defaultFileName()).to(equal("taylor_report.pmd"))
-//                expect(PlainReporter().defaultFileName()).to(equal("taylor_report.txt"))
-//                expect(XcodeReporter().defaultFileName()).to(equal(""))
-//            }
-//            it("should initialize with type name") {
-//                let type = Reporter(type:"PMD")
-//                expect(type).to(equal(ReporterType.PMD))
-//                let type1 = Reporter(type:"JSON")
-//                expect(type1).to(equal(ReporterType.JSON))
-//                let type2 = Reporter(type:"XCODE")
-//                expect(type2).to(equal(ReporterType.Xcode))
-//                let type3 = Reporter(type:"PLAIN")
-//                expect(type3).to(equal(ReporterType.Plain))
-//                let type4 = Reporter(type:"gsdgahgailh")
-//                expect(type4).to(equal(ReporterType.Plain))
-//            }
-//        }
-//    }
+    override func spec() {
+        describe("Reporter") {
+            it("should inittilize with type and file name") {
+                let reporter = Reporter(type: "", fileName: "just a name")
+                expect(reporter).toNot(beNil())
+                expect(reporter.concreteReporter is PlainReporter).to(beTrue())
+                expect(reporter.fileName).to(equal("just a name"))
+            }
+            it("should inittilize with type") {
+                let reporter = Reporter(type: "JSON")
+                expect(reporter).toNot(beNil())
+                expect(reporter.concreteReporter is JSONReporter).to(beTrue())
+                expect(reporter.fileName).to(equal("taylor_report.json"))
+            }
+        }
+        describe("ReporterType") {
+            it("should return the correct extension") {
+                expect(JSONReporter().fileExtension()).to(equal("json"))
+                expect(PMDReporter().fileExtension()).to(equal("pmd"))
+                expect(PlainReporter().fileExtension()).to(equal("txt"))
+                expect(XcodeReporter().fileExtension()).to(equal(""))
+            }
+            it("should return the correct default file names") {
+                expect(JSONReporter().defaultFileName()).to(equal("taylor_report.json"))
+                expect(PMDReporter().defaultFileName()).to(equal("taylor_report.pmd"))
+                expect(PlainReporter().defaultFileName()).to(equal("taylor_report.txt"))
+                expect(XcodeReporter().defaultFileName()).to(equal(""))
+            }
+            it("should initialize with type name") {
+                let type = Reporter(type:"PMD")
+                expect(type.concreteReporter is PMDReporter).to(beTrue())
+                let type1 = Reporter(type:"JSON")
+                expect(type1.concreteReporter is JSONReporter).to(beTrue())
+                let type2 = Reporter(type:"XCODE")
+                expect(type2.concreteReporter is XcodeReporter).to(beTrue())
+                let type3 = Reporter(type:"PLAIN")
+                expect(type3.concreteReporter is PlainReporter).to(beTrue())
+                let type4 = Reporter(type:"gsdgahgailh")
+                expect(type4.concreteReporter is PlainReporter).to(beTrue())
+            }
+        }
+    }
 }

--- a/TaylorFrameworkTests/TemperTests/TemperTests.swift
+++ b/TaylorFrameworkTests/TemperTests/TemperTests.swift
@@ -16,18 +16,18 @@ class TemperTests : QuickSpec {
     override func spec() {
         afterEach {
             let path = NSFileManager.defaultManager().currentDirectoryPath as NSString
-            let filePath = path.stringByAppendingPathComponent(ReporterType.JSON.defaultFileName())
+            let filePath = path.stringByAppendingPathComponent(JSONReporter().defaultFileName())
             NSFileManager().removeFileAtPath(filePath)
         }
         it("should detect the violations and create the file/files") {
             let aComponent = TestsHelper().aComponent
             let anotherComponent = TestsHelper().anotherComponent
             let path =  NSHomeDirectory() as NSString
-            let filePath = path.stringByAppendingPathComponent(ReporterType.JSON.defaultFileName())
+            let filePath = path.stringByAppendingPathComponent(JSONReporter().defaultFileName())
             let temper = Temper(outputPath: (path as String))
             aComponent.components = [anotherComponent]
             let content = FileContent(path: "blablabla", components: [aComponent])
-            let reporter = Reporter(type: .JSON, fileName: ReporterType.JSON.defaultFileName())
+            let reporter = JSONReporter()
             temper.setReporters([reporter])
             temper.checkContent(content)
             temper.finishTempering()

--- a/TaylorFrameworkTests/TemperTests/TemperTests.swift
+++ b/TaylorFrameworkTests/TemperTests/TemperTests.swift
@@ -28,7 +28,7 @@ class TemperTests : QuickSpec {
             aComponent.components = [anotherComponent]
             let content = FileContent(path: "blablabla", components: [aComponent])
             let reporter = JSONReporter()
-            temper.setReporters([reporter])
+            temper.setReporters([Reporter(reporter)])
             temper.checkContent(content)
             temper.finishTempering()
             let jsonData = NSData(contentsOfFile: filePath)


### PR DESCRIPTION
This refactor is an attempt to solve the problem of the following code:

``` language-swift
enum ReporterType {
    case JSON
    case PMD
    case Plain
    case Xcode
   }
```

The main issue with this code is that it is an enum, instead of four reporters implementing the Reporting protocol. If we were to add a new reporter, there would be parts of the software which would give errors(Like the OutputCoordinator class). Also if you have 4 independent reporters you can work on two different reporters in parallel, or not have merge conflicts. Decoupling things is generally good

The fact that this is an enum not a polymorphic protocol causes issues in different parts of the code.
 For example the _OutputCoordinator_ class, is forced to do something like this:

``` language-swift
 for reporter in reporters {
            switch reporter.type {
            case .JSON:  coordinator = JSONCoordinator()
            case .PMD:   coordinator = PMDCoordinator()
            case .Plain: coordinator = PLAINCoordinator()
            case .Xcode: coordinator = XcodeCoordinator()
            }
            let path = (filePath as NSString).stringByAppendingPathComponent(reporter.fileName)
            coordinator.writeViolations(violations, atPath: path)
        }
```

But after this refactor we can just ask the reporter for it's coordinator because each reporter implements this method:

``` language-swift
      for reporter in reporters {
            let path = (filePath as NSString).stringByAppendingPathComponent(reporter.fileName)
            reporter.coordinator().writeViolations(violations, atPath: path)
        }
```

This lends itself to further refactoring because it breaks demeter's law but it's still better.

Another example where the enum shows it's disadvantages is here:

``` language-swift
  func defaultFileName() -> String {
-        if self == .Xcode { return "" }
         return "taylor_report" + "." + fileExtension()
     }
```

This if check is a hack, that we have to check for a specific type. As other types are added, more if checks are needed. Contrast this with after the refactor:

``` language-swift
struct XcodeReporter: Reporting {
    func defaultFileName()-> String {
        return ""
    }
}
struct JSONReporter: Reporting {
    func defaultFileName()-> String {
        return  "taylor_report" + "." + fileExtension()
    }
}
```

Another example where the enum shows it's shortcomings is the fileExtension method:

`````` language-swift
    func fileExtension() -> String {
        switch self {
        case .JSON: return "json"
        case .PMD: return "pmd"
        case .Plain: return "txt"
        case .Xcode: return ""
        }
    }
    ```

We can define a method in the protocol, and let each reporter tell us it's fileExtension.
```language-Swift
protocol Reporting {
func fileExtension()-> String
}
``````

Another good outcome of using polymorphism. Code like this from the tests:

``` language-swift
            let reporter = Reporter(type: .JSON, fileName: ReporterType.JSON.defaultFileName())
```

Could eventually  be converted to this:

``` language-swift
            let reporter = JSONReporter()
```

This is not the case right now.

The last fix, is actually not connected this the enum. Instead of having two inits there

``` language-swift
    init(type : ReporterType, fileName : String) {
        self.type = type
        self.fileName = fileName
    }

    init (type : ReporterType) {
        self.init(type: type, fileName:type.defaultFileName())
    }
```

They can be reduced to a single init with an optional paramter:

``` language-swift
    init(type : String, fileName : String? = nil) {
        self.concreteReporter = reporterWithName(type)
        guard let fileName = fileName else {
            self.fileName = self.concreteReporter.defaultFileName()
            return
        }
        self.fileName  = fileName
    }
```
