### PR TITLE
Engineering/code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ xcode_project: Taylor.xcodeproj
 xcode_scheme: Taylor
 xcode_sdk: macosx
 osx_image: xcode7.1
+script: ./test.sh
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 A tool aimed to increase Swift code quality, by checking for conformance to code metrics.
 
 [![Build Status](https://travis-ci.org/yopeso/Taylor.svg?branch=master)](https://travis-ci.org/yopeso/Taylor)
+[![codecov.io](https://codecov.io/github/yopeso/Taylor/coverage.svg?branch=master)](https://codecov.io/github/yopeso/Taylor?branch=master)
 
 Taylor uses [SourceKitten](https://github.com/S2dentik/SourceKitten) to a more
 accurate [AST](http://clang.llvm.org/docs/IntroductionToTheClangAST.html)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+TEST_CMD="xcodebuild -scheme Taylor -sdk macosx10.11 build test"
+
+which -s xcpretty
+XCPRETTY_INSTALLED=$?
+
+if [[ $TRAVIS || $XCPRETTY_INSTALLED == 0 ]]; then
+  eval "${TEST_CMD} | xcpretty"
+else
+  eval "$TEST_CMD"
+fi


### PR DESCRIPTION
This PR enables code coverage status to be displayed for Taylor.I do not own Taylor so I have enabled code coverage for my fork of taylor (see the little Codecov button): https://github.com/thebugcode/Taylor

This PR enables code coverage to be sent to codecov.io

I have taken care of the setup details according to this guide https://github.com/codecov/example-swift/ so you only need to go to https://codecov.io/# and enable yopeso/Taylor. You can also give it PR access by clicking on the project, then settings, to get messages like the one below from coveralls (especially useful when PR's decrease the code coverage).

The alternative to codecov.io is coveralls.io. Integration of coveralls is not as easy (http://list.her.sh/ios-test-coverage-with-coveralls/) but you can switch back and forth between the two. For example here is a PR where someone switched from coveralls to codecov: https://github.com/splinesoft/SSDataSources/commit/9ef0465ca82086ea3ca1245cc60749dabfa86f08
