### PR TITLE
Fix violations

### DIFF
--- a/TaylorFramework/Modules/temper/Output/PLAINCoordinator.swift
+++ b/TaylorFramework/Modules/temper/Output/PLAINCoordinator.swift
@@ -25,8 +25,7 @@ final class PLAINCoordinator : WritingCoordinator {
     }
     
     private func generateFileContentHeader() -> String {
-        var content =  "\nSummary: TotalFiles=\(Temper.totalFiles) FilesWithViolations=\(Temper.filesWithViolations) "
-        content += "P1=\(Temper.violationsWithP1) P2=\(Temper.violationsWithP2) P3=\(Temper.violationsWithP3)\n\n"
-        return content
+        return "\nSummary: TotalFiles=\(Temper.statistics.totalFiles) FilesWithViolations=\(Temper.statistics.filesWithViolations) " +
+            "P1=\(Temper.statistics.violationsWithP1) P2=\(Temper.statistics.violationsWithP2) P3=\(Temper.statistics.violationsWithP3)\n\n"
     }
 }

--- a/TaylorFramework/Modules/temper/Output/PMDCoordinator.swift
+++ b/TaylorFramework/Modules/temper/Output/PMDCoordinator.swift
@@ -48,16 +48,3 @@ final class PMDCoordinator : WritingCoordinator {
         return violations.map({ $0.path }).unique
     }
 }
-
-extension Array where Element : Hashable {
-    
-    /**
-        This property delete the duplicated objects in the array
-        
-        :returns: [Element] An array with distinct objects
-    */
-    
-    var unique: [Element] {
-        return Array(Set(self))
-    }
-}

--- a/TaylorFramework/Modules/temper/Rules/Rule.swift
+++ b/TaylorFramework/Modules/temper/Rules/Rule.swift
@@ -44,7 +44,7 @@ protocol Rule {
         :returns: Int? value The value of the violation, if the component is violation the rule
     */
     
-    func checkComponent(component: Component) -> (isOk: Bool, message: String?, value: Int?)
+    func checkComponent(component: Component) -> Result
     
     /**
         The method format the message for reporters

--- a/TaylorFramework/Modules/temper/Violations/Violation.swift
+++ b/TaylorFramework/Modules/temper/Violations/Violation.swift
@@ -8,6 +8,17 @@
 
 import Foundation
 
+struct ViolationData {
+    let message: String
+    let path: String
+    let value: Int
+    init(message: String, path: String, value: Int) {
+        self.message = message
+        self.path = path
+        self.value = value
+    }
+}
+
 struct Violation {
     
     var path : String
@@ -16,12 +27,12 @@ struct Violation {
     let message : String
     let value : Int
     
-    init(component: Component, rule: Rule, message: String, path: String, value: Int) {
+    init(component: Component, rule: Rule, violationData: ViolationData) {
         self.component = component
         self.rule = rule
-        self.message = message
-        self.value = value
-        self.path = path.stringByReplacingOccurrencesOfString("\\", withString: "", options: NSStringCompareOptions.LiteralSearch, range: nil)
+        self.message = violationData.message
+        self.value = violationData.value
+        self.path = violationData.path.stringByReplacingOccurrencesOfString("\\", withString: "", options: NSStringCompareOptions.LiteralSearch, range: nil)
     }
     
     func toDictionary() -> Dictionary<String, AnyObject> {

--- a/TaylorFramework/Taylor/Array+Extensions.swift
+++ b/TaylorFramework/Taylor/Array+Extensions.swift
@@ -37,9 +37,7 @@ extension Array {
                     }
                 }
                 
-                dispatch_group_async(group, lock) {
-                    result += [(capturedStepIndex, stepResult)]
-                }
+                dispatch_group_async(group, lock) { result += [(capturedStepIndex, stepResult)] }
             }
         }
         

--- a/TaylorFrameworkTests/CapriceTests/Tests/MessageProcessorTests.swift
+++ b/TaylorFrameworkTests/CapriceTests/Tests/MessageProcessorTests.swift
@@ -125,14 +125,14 @@ class MessageProcessorTests: QuickSpec {
                     expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
                 }
                 
-                it("default excludes file must be readed and setted to result dictionary if it exists, in plus at default path and type") {
+                it("default excludes file must be read and set to result dictionary if it exists, in plus at default path and type") {
                     let mockMessageProcessor = MockMessageProcessor()
                     let inputArguments = [currentPath]
                     let resultsArrayOfExcludes = ["file.txt".formattedExcludePath(currentPath), "path/to/file.txt".formattedExcludePath(currentPath), "folder".formattedExcludePath(currentPath), "path/to/folder".formattedExcludePath(currentPath)]
                     expect(mockMessageProcessor.processArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : ["swift"], "excludes" : resultsArrayOfExcludes]))
                 }
                 
-                it("should set exclude path and paths from excludeFile toghether") {
+                it("should set exclude path and paths from excludeFile together") {
                     let mockMessageProcessor = MockMessageProcessor()
                     let somePath = "/somePath"
                     let pathToExcludesFile = MockFileManager().testFile("excludes", fileType: "yml")
@@ -154,7 +154,7 @@ class MessageProcessorTests: QuickSpec {
             
             context("when single option is indicated") {
                 
-                it("should return error dictionary if help file wasnt found") {
+                it("should return error dictionary if help file was not found") {
                     let mockMessageProcessor = MockMessageProcessor()
                     let inputArguments = [currentPath, FlagKey]
                     expect(mockMessageProcessor.processArguments(inputArguments)).to(beEmpty())

--- a/TaylorFrameworkTests/TemperTests/OutputCoordinatorTests.swift
+++ b/TaylorFrameworkTests/TemperTests/OutputCoordinatorTests.swift
@@ -42,7 +42,7 @@ class OutputCoordinatorTests : QuickSpec {
             it("should write the violations in JSON file") {
                 let aComponent = TestsHelper().aComponent
                 let aRule = TestsHelper().aRule
-                let violation = Violation(component: aComponent, rule: aRule, message: "msg", path: "path", value: 100)
+                let violation = Violation(component: aComponent, rule: aRule, violationData: ViolationData(message: "msg", path: "path", value: 100))
                 let filePath = (self.reporterPath as NSString).stringByAppendingPathComponent(JSONReporter().defaultFileName())
                 OutputCoordinator(filePath: self.reporterPath).writeTheOutput([violation], reporters: [Reporter(JSONReporter())])
                 let jsonData = NSData(contentsOfFile: filePath)
@@ -78,7 +78,7 @@ class OutputCoordinatorTests : QuickSpec {
                 let aRule = TestsHelper().aRule
                 let component = aComponent
                 let childComponent = component.makeComponent(type: ComponentType.Function, range: ComponentRange(sl: 10, el: 30), name: "justFunction")
-                let violation = Violation(component: childComponent, rule: aRule, message: "msg", path: "path", value: 100)
+                let violation = Violation(component: childComponent, rule: aRule, violationData: ViolationData(message: "msg", path: "path", value: 100))
                 let filePath = (self.reporterPath as NSString).stringByAppendingPathComponent(PMDReporter().defaultFileName())
                 OutputCoordinator(filePath: self.reporterPath).writeTheOutput([violation], reporters: [Reporter(PMDReporter())])
                 let xmlData = NSData(contentsOfFile: filePath)
@@ -129,7 +129,7 @@ class OutputCoordinatorTests : QuickSpec {
                 temper.finishTempering()
                 expect(NSFileManager.defaultManager().fileExistsAtPath(filePath)).to(beTrue())
                 let path = "trololo"
-                let violation = Violation(component: aComponent, rule: NestedBlockDepthRule(), message: "msg", path: "path", value: 100)
+                let violation = Violation(component: aComponent, rule: NestedBlockDepthRule(), violationData: ViolationData(message: "msg", path: "path", value: 100))
                 OutputCoordinator(filePath: path).writeTheOutput([violation], reporters: [Reporter(PlainReporter())])
                 expect(NSFileManager.defaultManager().fileExistsAtPath(path)).to(beFalse())
                 NSFileManager.defaultManager().removeFileAtPath(folderPath)

--- a/TaylorFrameworkTests/TemperTests/TemperTests.swift
+++ b/TaylorFrameworkTests/TemperTests/TemperTests.swift
@@ -92,9 +92,9 @@ class TemperTests : QuickSpec {
             temper.rules = [rule1, rule2, rule3, rule4]
             let content = FileContent(path: "", components: [self.helper.whileComponent])
             temper.checkContent(content)
-            expect(Temper.violationsWithP1).to(beGreaterThan(0))
-            expect(Temper.violationsWithP2).to(beGreaterThan(0))
-            expect(Temper.violationsWithP3).to(beGreaterThan(0))
+            expect(Temper.statistics.violationsWithP1).to(beGreaterThan(0))
+            expect(Temper.statistics.violationsWithP2).to(beGreaterThan(0))
+            expect(Temper.statistics.violationsWithP3).to(beGreaterThan(0))
         }
     }
 }

--- a/TaylorFrameworkTests/TemperTests/ViolationTests.swift
+++ b/TaylorFrameworkTests/TemperTests/ViolationTests.swift
@@ -15,10 +15,14 @@ class ViolationTests : QuickSpec {
     let helper : TestsHelper = TestsHelper()
     let aComponent = TestsHelper().anotherComponent
     let aRule = TestsHelper().aRule
+    
     override func spec() {
+        var violation: Violation!
+        beforeEach() {
+            violation = Violation(component: self.aComponent, rule: self.aRule, violationData: ViolationData(message: "msg", path: "path", value: 100))
+        }
         describe("Violation") {
             it("should instantiate from component, rule, message and path") {
-                let violation = Violation(component: self.aComponent, rule: self.aRule, message: "msg", path: "path", value: 100)
                 expect(violation.component).to(equal(self.aComponent))
                 expect(violation.rule.rule).to(equal(self.aRule.rule))
                 expect(violation.message).to(equal("msg"))
@@ -27,7 +31,6 @@ class ViolationTests : QuickSpec {
                 expect(violation.rule.externalInfoUrl).to(equal(self.aRule.externalInfoUrl))
             }
             it("should return the correct dictionary") {
-                let violation = Violation(component: self.aComponent, rule: self.aRule, message: "msg", path: "path", value: 100)
                 let violationDictionary = violation.toDictionary()
                 expect(violation.message).to(equal(violationDictionary["message"] as? String))
                 expect(violation.rule.rule).to(equal(violationDictionary["rule"] as? String))
@@ -43,20 +46,19 @@ class ViolationTests : QuickSpec {
                 let classComponent = Component(type: .Class, range: ComponentRange(sl: 0, el: 0), name: "TheClass")
                 let component = self.helper.ifComponent
                 component.parent = classComponent
-                let violation = Violation(component: component, rule: self.aRule, message: "msg", path: "path", value: 100)
+                let violation = Violation(component: component, rule: self.aRule, violationData: ViolationData(message: "msg", path: "path", value: 100))
                 let violationDictionary = violation.toDictionary()
                 expect(violation.message).to(equal(violationDictionary["message"] as? String))
                 expect(violation.rule.rule).to(equal(violationDictionary["rule"] as? String))
                 expect(violation.path).to(equal(violationDictionary["path"] as? String))
                 expect(violation.rule.priority).to(equal(violationDictionary["priority"] as? Int))
-                expect(violation.rule.externalInfoUrl).to(equal(violationDictionary["externalInfoUrl"] as? String))
+            expect(violation.rule.externalInfoUrl).to(equal(violationDictionary["externalInfoUrl"] as? String))
                 expect(violation.value).to(equal(violationDictionary["value"] as? Int))
                 expect(violation.component.name).to(equal(violationDictionary["method"] as? String))
                 let range = ComponentRange.deserialize(violationDictionary)
                 expect(violation.component.range).to(equal(range))
             }
             it("should return the correct XML element") {
-                let violation = Violation(component: self.aComponent, rule: self.aRule, message: "msg", path: "path", value: 100)
                 let element = violation.toXMLElement()
                 expect(element.stringValue).to(equal("msg"))
                 let attributes = element.attributes
@@ -77,8 +79,6 @@ class ViolationTests : QuickSpec {
                 expect(attributes).to(contain(NSXMLNode.attributeWithName("endline", stringValue: String(self.aComponent.range.endLine)) as? NSXMLNode))
             }
             it("should remove backslashes from path when creating the violation") {
-                let path = "\\/Users\\/iosintern2\\/Desktop\\/taylor\\/temper\\/trololo\\/"
-                let violation = Violation(component: self.aComponent, rule: self.aRule, message: "msg", path: path, value: 100)
                 var containsBackslash = false
                 for character in violation.path.characters {
                     if character == "\\" {
@@ -88,7 +88,7 @@ class ViolationTests : QuickSpec {
                 expect(containsBackslash).to(beFalse())
             }
             it("should return the correct error string for stderr") {
-                let violation = Violation(component: self.aComponent, rule: self.aRule, message: "msg", path: "thepath", value: 50)
+                let violation = Violation(component: self.aComponent, rule: self.aRule, violationData: ViolationData(message: "msg", path: "thepath", value: 50))
                 let errorString = violation.errorString
                 expect(errorString).to(equal("thepath:\(self.aComponent.range.startLine):0: warning: \(self.aRule.rule)(P\(self.aRule.priority)):msg\n"))
                 


### PR DESCRIPTION
Add ViolationData struct

This struct encapsulates some arguments passed to Violation thus reducing init arguments
and increasing readability.

Add TemperStatistics struct

This struct encapsulates statistics about Temper class to reduce complexity and instance variables over
the class.

Refactor Finder class

Add generic removeDuplicated() extension over array, make some functions
extensions over the class.

Remove violations in Scissors

Make methods ExtendedComponent doesn't depend upon extensions.
Refactor appendComponents(_:_:) method.
Remove parent from list of parameters over ExtendedComponent and make it
nil by default.

Refactor NPath Complexity

Add extensions on ComponentType for a more self-explaining way of calculating
complexity over a component.

Remove some newlines to clear the corresponding warning

Refactor Temper

Reduce CyclomaticComplexity of checkPair(_:_:) and updateStatistics(_:_:) methods.

Refactor Caprice module

Add reduceTwoElements(_:_:) function to iterate over the arguments intercepted by the module.
Refactor optionObjectFromOption(_:_:) to work more generically and reduce complexity.
