### PR TITLE
Fix closure parameters bug

### DIFF
--- a/Taylor.xcodeproj/project.pbxproj
+++ b/Taylor.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		692FCBEE1BED2C2A00DB5F16 /* TaylorFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69B4DC891BED1BD3005EA7D5 /* TaylorFramework.framework */; };
 		692FCBF31BED2E2A00DB5F16 /* install in Resources */ = {isa = PBXBuildFile; fileRef = 692FCBF21BED2E2A00DB5F16 /* install */; };
 		692FCBF41BED2E8400DB5F16 /* TaylorFramework.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 69B4DC891BED1BD3005EA7D5 /* TaylorFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		69400EC81C32935B0065CDB0 /* TestFileClosureParameters.txt in Copy Files (23 items) */ = {isa = PBXBuildFile; fileRef = 69400EC61C32934B0065CDB0 /* TestFileClosureParameters.txt */; };
 		69461E0A1BF61D2C00AF5B5C /* CLIReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69461E091BF61D2C00AF5B5C /* CLIReporterTests.swift */; };
 		69517A1A1BF25C31000B3F1B /* CLIReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69517A191BF25C31000B3F1B /* CLIReporter.swift */; };
 		69B4DC951BED1BF6005EA7D5 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B4DBE41BED169B005EA7D5 /* Component.swift */; };
@@ -245,6 +246,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 7;
 			files = (
+				69400EC81C32935B0065CDB0 /* TestFileClosureParameters.txt in Copy Files (23 items) */,
 				69B4DDA81BED209C005EA7D5 /* emptyExcludes.yml in Copy Files (23 items) */,
 				69B4DDA91BED209C005EA7D5 /* excludes.yml in Copy Files (23 items) */,
 				69B4DD911BED208F005EA7D5 /* TestFileBraceWithParameter.txt in Copy Files (23 items) */,
@@ -302,6 +304,7 @@
 		692FCBDD1BED2A2400DB5F16 /* Taylor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Taylor.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		692FCBEA1BED2B7F00DB5F16 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		692FCBF21BED2E2A00DB5F16 /* install */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = install; sourceTree = "<group>"; };
+		69400EC61C32934B0065CDB0 /* TestFileClosureParameters.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestFileClosureParameters.txt; sourceTree = "<group>"; };
 		69461E091BF61D2C00AF5B5C /* CLIReporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CLIReporterTests.swift; sourceTree = "<group>"; };
 		69517A191BF25C31000B3F1B /* CLIReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CLIReporter.swift; sourceTree = "<group>"; };
 		69B4DBDE1BED169B005EA7D5 /* TaylorFramework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TaylorFramework.h; path = Headers/TaylorFramework.h; sourceTree = "<group>"; };
@@ -890,6 +893,7 @@
 		69B4DD0B1BED1FE0005EA7D5 /* TestFiles */ = {
 			isa = PBXGroup;
 			children = (
+				69400EC61C32934B0065CDB0 /* TestFileClosureParameters.txt */,
 				69B4DD0C1BED1FE0005EA7D5 /* TestFileBraceWithParameter.txt */,
 				69B4DD0D1BED1FE0005EA7D5 /* TestFileClosures.txt */,
 				69B4DD0E1BED1FE0005EA7D5 /* TestFileComments.txt */,

--- a/TaylorFramework/Modules/scissors/ComponentFinder.swift
+++ b/TaylorFramework/Modules/scissors/ComponentFinder.swift
@@ -83,9 +83,9 @@ struct ComponentFinder {
         let settersRanges = findRanges("(set($|[ \\t\\n{}]))", text: text)
         if gettersRanges.isEmpty { return findObserverGetters(text) }
         
-        accessors.append(ExtendedComponent(type: .Function, range: gettersRanges.first!, name: "get"))
+        accessors.append(ExtendedComponent(type: .Function, range: gettersRanges.first!, names: ("get", nil)))
         if !settersRanges.isEmpty {
-            accessors.append(ExtendedComponent(type: .Function, range: settersRanges.first!, name: "set"))
+            accessors.append(ExtendedComponent(type: .Function, range: settersRanges.first!, names: ("set", nil)))
         }
         accessors.sortInPlace( { $0.offsetRange.start < $1.offsetRange.start } )
         if accessors.count == 1 {
@@ -103,10 +103,10 @@ struct ComponentFinder {
         var didSetRanges = findRanges("(didSet($|[ \\t\\n{}]))", text: text)
         var observers = [ExtendedComponent]()
         if willSetRanges.count > 0 {
-            observers.append(ExtendedComponent(type: .Function, range: willSetRanges[0], name: "willSet"))
+            observers.append(ExtendedComponent(type: .Function, range: willSetRanges[0], names: ("willSet", nil)))
         }
         if didSetRanges.count > 0 {
-            observers.append(ExtendedComponent(type: .Function, range: didSetRanges[0], name: "didSet"))
+            observers.append(ExtendedComponent(type: .Function, range: didSetRanges[0], names: ("didSet", nil)))
         }
         observers.sortInPlace { $0.offsetRange.start < $1.offsetRange.start }
         if observers.count == 1 {

--- a/TaylorFramework/Modules/scissors/ExtendedComponent.swift
+++ b/TaylorFramework/Modules/scissors/ExtendedComponent.swift
@@ -10,19 +10,36 @@ import Foundation
 import SourceKittenFramework
 import SwiftXPC
 
+typealias Names = (name: String?, typeName: String?)
+
 final class ExtendedComponent {
     
     var offsetRange: OffsetRange
     var type: ComponentType
-    var name: String?
+    var names: Names
     var parent: ExtendedComponent? = nil
     var components: [ExtendedComponent]
     
-    init(type: ComponentType, range: OffsetRange, name: String? = nil) {
+    var name: String? {
+        get {
+            return names.name
+        }
+        set {
+            names.name = name
+        }
+    }
+    
+    var typeName: String? {
+        get {
+            return names.typeName
+        }
+    }
+    
+    init(type: ComponentType, range: OffsetRange, names: Names = (nil, nil)) {
         self.type = type
         self.offsetRange = range
         self.components = []
-        self.name = name
+        self.names = names
     }
     
     init(dict: [String: AnyObject]) {
@@ -36,7 +53,7 @@ final class ExtendedComponent {
             self.type = .Other
             self.offsetRange = OffsetRange(start: 0, end: 0)
         }
-        self.name = nil
+        self.names = (nil, nil)
         self.components = []
     }
     
@@ -50,7 +67,7 @@ final class ExtendedComponent {
                 if bodyOffsetEnd != 0 { offsetRange.end = bodyOffsetEnd }
             } else if type.isOther { return }
             if type.isBrace { braces++ }
-            let child = ExtendedComponent(type: type, range: offsetRange, name: structure.asDictionary.name)
+            let child = ExtendedComponent(type: type, range: offsetRange, names: (structure.asDictionary.name, structure.asDictionary.typeName))
             components.append(child)
             components = child.appendComponents(components, array: structure.asDictionary.substructure)
         }

--- a/TaylorFramework/Modules/scissors/Tree.swift
+++ b/TaylorFramework/Modules/scissors/Tree.swift
@@ -27,7 +27,7 @@ struct Tree {
     //MARK: Dictionary to tree methods
     
     func makeTree() -> Component {
-        let root = ExtendedComponent(type: .Other, range: dictionary.offsetRange)
+        let root = ExtendedComponent(type: .Other, range: dictionary.offsetRange, names: (nil, nil))
         let noStringsText = replaceStringsWithSpaces(parts.map() { $0.contents })
         
         let finder = ComponentFinder(text: noStringsText, syntaxMap: syntaxMap)
@@ -37,14 +37,20 @@ struct Tree {
         root.removeRedundantClosures()
         processBraces(root)
         arrayToTree(additionalComponents(finder), root: root)
-        root.variablesToFunctions()
-        sortTree(root)
+        processTree(root)
         
         return convertTree(root)
     }
     
     func additionalComponents(finder: ComponentFinder) -> [ExtendedComponent] {
         return finder.findComments() + finder.findLogicalOperators() + finder.findEmptyLines()
+    }
+    
+    func processTree(root: ExtendedComponent) {
+        root.variablesToFunctions()
+        root.processParameters()
+        root.removeRedundantParameters()
+        sortTree(root)
     }
     
     //MARK: Conversion to Component type
@@ -66,11 +72,9 @@ struct Tree {
     }
     
     func offsetToLine(offsetRange: OffsetRange) -> ComponentRange {
-        
         let startIndex = parts.filter() { $0.startOffset <= offsetRange.start }.count - 1
         let endIndex = parts.filter() { $0.startOffset <= offsetRange.end }.count - 1
     
-        
         return ComponentRange(sl: parts[startIndex].getLineRange(offsetRange.start), el: parts[endIndex].getLineRange(offsetRange.end))
     }
     
@@ -98,7 +102,7 @@ struct Tree {
             processBraces(component)
         }
     }
-    
+
     func sortTree(root: ExtendedComponent) {
         for component in root.components {
             sortTree(component)

--- a/TaylorFrameworkTests/ScissorsTests/Resources/ComponentsBuilder.swift
+++ b/TaylorFrameworkTests/ScissorsTests/Resources/ComponentsBuilder.swift
@@ -216,3 +216,21 @@ func componentsForBraceWithParameters() -> [Component] {
     var1.makeComponent(type: .If, range: ComponentRange(sl: 3, el: 3))
     return [root]
 }
+
+func componentsForClosureParameters() -> [Component] {
+    let function1 = Component(type: .Function, range: ComponentRange(sl: 1, el: 3))
+    function1.makeComponent(type: .Parameter, range: ComponentRange(sl: 1, el: 1))
+    function1.makeComponent(type: .Parameter, range: ComponentRange(sl: 1, el: 1))
+    function1.makeComponent(type: .Parameter, range: ComponentRange(sl: 1, el: 1))
+    let closure = function1.makeComponent(type: .Closure, range: ComponentRange(sl: 2, el: 2))
+    closure.makeComponent(type: .Parameter, range: ComponentRange(sl: 2, el: 2))
+    closure.makeComponent(type: .Parameter, range: ComponentRange(sl: 2, el: 2))
+    closure.makeComponent(type: .Parameter, range: ComponentRange(sl: 2, el: 2))
+    
+    let function2 = Component(type: .Function, range: ComponentRange(sl: 4, el: 7))
+    function2.makeComponent(type: .Parameter, range: ComponentRange(sl: 4, el: 4))
+    function2.makeComponent(type: .Parameter, range: ComponentRange(sl: 4, el: 4))
+    function2.makeComponent(type: .Parameter, range: ComponentRange(sl: 4, el: 4))
+
+    return [function1, function2]
+}

--- a/TaylorFrameworkTests/ScissorsTests/TestFiles/TestFileClosureParameters.txt
+++ b/TaylorFrameworkTests/ScissorsTests/TestFiles/TestFileClosureParameters.txt
@@ -1,0 +1,7 @@
+func testClosureParameters(a: Int, b: String, c: Float) {
+[1, 2, 3].reduce(0) { $0 + $1 }
+}
+func testFilterClosureParameters(a: Int, b: String, c: Float) {
+    let test = [1, 2, 3].filter { $0 == 1 }
+    let test2 = [1, 2, 3, 4].map { a in a * 2 }
+}

--- a/TaylorFrameworkTests/ScissorsTests/Tests/TokenizerTests.swift
+++ b/TaylorFrameworkTests/ScissorsTests/Tests/TokenizerTests.swift
@@ -163,6 +163,12 @@ class TokenizerTests: QuickSpec {
                 let path = reader.pathForFile("TestFileMoreThan3K", fileType: "swift")
                 _ = Scissors().tokenizeFileAtPath(path)
             }
+            it("should distinguish function parameters from shorthand closure ones") {
+                let path = reader.pathForFile("TestFileClosureParameters", fileType: "txt")
+                let returnContent = Scissors().tokenizeFileAtPath(path)
+                let expectedContent = FileContent(path: path, components: componentsForClosureParameters())
+                expect(returnContent).to(equal(expectedContent))
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed the bug when closure parameters were recognized by sourcekit as simple ones
and were processed by scissors as function parameters, thus leading to tooManyArguments
Violation trigger. Added typeName field to ExtendedComponent, processParameters(_:) method
and tests.
