### PR TITLE
Fix empty filename for reporter bug

### DIFF
--- a/TaylorFramework/Modules/temper/Output/OutputCoordinator.swift
+++ b/TaylorFramework/Modules/temper/Output/OutputCoordinator.swift
@@ -19,6 +19,7 @@ final class OutputCoordinator {
     func writeTheOutput(violations: [Violation], reporters: [Reporter]) {
         self.reporters = reporters
         for reporter in reporters {
+            if reporter.fileName.isEmpty { continue }
             let path = (filePath as NSString).stringByAppendingPathComponent(reporter.fileName)
             reporter.coordinator().writeViolations(violations, atPath: path)
         }

--- a/TaylorFrameworkTests/CapriceTests/Tests/ReporterOptionTests.swift
+++ b/TaylorFrameworkTests/CapriceTests/Tests/ReporterOptionTests.swift
@@ -30,9 +30,9 @@ class ReporterOptionTests: QuickSpec {
                 }.toNot(throwError())
             }
             
-            it("should set empty value for path key if second component of arguments is nil") {
+            it("should not set a value for path key if second component of arguments is nil") {
                 reporter.optionArgument = JsonType
-                expect(reporter.dictionaryFromArgument()).to(equal(["fileName" : "", "type" : JsonType]))
+                expect(reporter.dictionaryFromArgument()).to(equal(["type" : JsonType]))
             }
             
         }

--- a/TaylorFrameworkTests/TemperTests/ReporterTests.swift
+++ b/TaylorFrameworkTests/TemperTests/ReporterTests.swift
@@ -13,13 +13,13 @@ import Quick
 class ReporterTests: QuickSpec {
     override func spec() {
         describe("Reporter") {
-            it("should inittilize with type and file name") {
+            it("should initialize with type and file name") {
                 let reporter = Reporter(type: "", fileName: "just a name")
                 expect(reporter).toNot(beNil())
                 expect(reporter.concreteReporter is PlainReporter).to(beTrue())
                 expect(reporter.fileName).to(equal("just a name"))
             }
-            it("should inittilize with type") {
+            it("should initialize with type") {
                 let reporter = Reporter(type: "JSON")
                 expect(reporter).toNot(beNil())
                 expect(reporter.concreteReporter is JSONReporter).to(beTrue())


### PR DESCRIPTION
Taylor was creating a report instead of the current directory if no file name was specified after report type. Now it ignores the report command if it doesn't contain a name.
