### PR TITLE
Edit Makefile, get rid of 'install_homebrew' action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,23 @@
 TEMPORARY_FOLDER?=$(HOME)/tmp
-PREFIX?=/usr/local/AppTool/Taylor
+PREFIX?=/usr/local/tools/Taylor
 BUILD_TOOL?=xcodebuild
 PACKAGE_NAME?=Taylor.app
 BUILD_DESTINATION?=$(TEMPORARY_FOLDER)/Build/Products/Release
 
 XCODEFLAGS=-scheme Taylor -derivedDataPath $(TEMPORARY_FOLDER)/ -configuration Release
 
-.PHONY: build install install_homebrew 
+.PHONY: build install
 
 build:
 	$(BUILD_TOOL) $(XCODEFLAGS) build
 
 install:
 	make build
-	mkdir -p "$(PREFIX)"
 
-	cp -rf "$(TEMPORARY_FOLDER)/Build/Products/Release/$(PACKAGE_NAME)" "$(PREFIX)/bin/"
-	ln -sf "$(PREFIX)/bin/Contents/MacOS/Taylor" "/usr/local/bin/taylor"
-	make remove
-
-install_homebrew:
-	make build
-	mkdir -p "$(PREFIX)/Frameworks" "$(PREFIX)/bin"
-	cp -f "$(BUILD_DESTINATION)/$(PACKAGE_NAME)/Contents/MacOS/Taylor" "$(PREFIX)/bin/taylor"
-	cp -Rf "$(BUILD_DESTINATION)/$(PACKAGE_NAME)/Contents/Frameworks/" "$(PREFIX)/Frameworks/"
+	ditto "$(BUILD_DESTINATION)/$(PACKAGE_NAME)/Contents/MacOS/Taylor" "$(PREFIX)/bin/taylor"
+	ditto "$(BUILD_DESTINATION)/$(PACKAGE_NAME)/Contents/Frameworks/" "$(PREFIX)/Frameworks/"
+	ln -sf "$(PREFIX)/bin/taylor" "/usr/local/bin/taylor"
+	
 	make remove
 
 remove:


### PR DESCRIPTION
Now `make install` can be used in Homebrew's formula as well as when installing Taylor from command line.
