### PR TITLE
Improve compile time

### DIFF
--- a/Taylor.xcodeproj/project.pbxproj
+++ b/Taylor.xcodeproj/project.pbxproj
@@ -1394,7 +1394,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/CommonTestsSources",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1417,7 +1416,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/CommonTestsSources",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				INFOPLIST_FILE = TaylorIntegrationTests/Info.plist;

--- a/TaylorFramework/Modules/BoundariesKit/Component.swift
+++ b/TaylorFramework/Modules/BoundariesKit/Component.swift
@@ -60,7 +60,8 @@ final class Component {
 
 extension Component : Hashable {
     var hashValue: Int {
-        return components.reduce(range.startLine.hashValue + range.endLine.hashValue + type.hashValue) { $0 + $1.hashValue }
+        let initialValue = range.startLine.hashValue + range.endLine.hashValue + type.hashValue
+        return components.reduce(initialValue) { $0 + $1.hashValue }
     }
 }
 

--- a/TaylorFramework/Modules/scissors/ComponentFinder.swift
+++ b/TaylorFramework/Modules/scissors/ComponentFinder.swift
@@ -22,19 +22,41 @@ struct ComponentFinder {
     }
     
     func findLogicalOperators() -> [ExtendedComponent] {
-        let boolOperators =
-            text.findMatchRanges("(\\|\\|)").map { ExtendedComponent(type: .Or, range: $0) } +
-            text.findMatchRanges("(\\&\\&)").map { ExtendedComponent(type: .And, range: $0) }
+        var operators = findOROperators()
+        operators.appendContentsOf(findANDOperators())
+        operators.appendContentsOf(findTernaryOperators())
+        operators.appendContentsOf(findNilCoalescingOperators())
+        
+        return operators
+    }
+    
+    func findOROperators() -> [ExtendedComponent] {
+        return text.findMatchRanges("(\\|\\|)").map {
+            ExtendedComponent(type: .Or, range: $0)
+        }
+    }
+    
+    func findANDOperators() -> [ExtendedComponent] {
+        return text.findMatchRanges("(\\&\\&)").map {
+            ExtendedComponent(type: .And, range: $0)
+        }
+    }
+    
+    func findTernaryOperators() -> [ExtendedComponent] {
         return text.findMatchRanges("(\\s+\\?(?!\\?).*?:)").map {
-                ExtendedComponent(type: .Ternary, range: $0)
-            } + text.findMatchRanges("(\\?\\?)").map {
-                ExtendedComponent(type: .NilCoalescing, range: $0)
-        } + boolOperators
+            ExtendedComponent(type: .Ternary, range: $0)
+        }
+    }
+    
+    func findNilCoalescingOperators() -> [ExtendedComponent] {
+        return text.findMatchRanges("(\\?\\?)").map {
+            ExtendedComponent(type: .NilCoalescing, range: $0)
+        }
     }
     
     func findComments() -> [ExtendedComponent] {
         return syntaxMap.tokens.filter {
-                types[$0.type] == .Comment
+            types[$0.type] == .Comment
             }.reduce([ExtendedComponent]()) {
                 $0 + ExtendedComponent(dict: $1.dictionaryValue)
         }

--- a/TaylorFramework/Modules/scissors/ScissorsExtensions.swift
+++ b/TaylorFramework/Modules/scissors/ScissorsExtensions.swift
@@ -315,7 +315,8 @@ extension ExtendedComponent {
 
 extension ExtendedComponent : Hashable {
     var hashValue: Int {
-        return components.reduce(offsetRange.start.hashValue + offsetRange.end.hashValue + type.hashValue) { $0 + $1.hashValue }
+        let initialValue = offsetRange.start.hashValue + offsetRange.end.hashValue + type.hashValue
+        return components.reduce(initialValue) { $0 + $1.hashValue }
     }
 }
 

--- a/TaylorFramework/Modules/scissors/Tree.swift
+++ b/TaylorFramework/Modules/scissors/Tree.swift
@@ -43,7 +43,11 @@ struct Tree {
     }
     
     func additionalComponents(finder: ComponentFinder) -> [ExtendedComponent] {
-        return finder.findComments() + finder.findLogicalOperators() + finder.findEmptyLines()
+        var components = finder.findComments()
+        components.appendContentsOf(finder.findLogicalOperators())
+        components.appendContentsOf(finder.findEmptyLines())
+        
+        return components
     }
     
     func processTree(root: ExtendedComponent) {
@@ -74,7 +78,7 @@ struct Tree {
     func offsetToLine(offsetRange: OffsetRange) -> ComponentRange {
         let startIndex = parts.filter() { $0.startOffset <= offsetRange.start }.count - 1
         let endIndex = parts.filter() { $0.startOffset <= offsetRange.end }.count - 1
-    
+        
         return ComponentRange(sl: parts[startIndex].getLineRange(offsetRange.start), el: parts[endIndex].getLineRange(offsetRange.end))
     }
     
@@ -102,7 +106,7 @@ struct Tree {
             processBraces(component)
         }
     }
-
+    
     func sortTree(root: ExtendedComponent) {
         for component in root.components {
             sortTree(component)

--- a/TaylorFramework/Modules/temper/Rules/NestedBlockDepthRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NestedBlockDepthRule.swift
@@ -47,7 +47,8 @@ final class NestedBlockDepthRule : Rule {
             return 0
         }
         
-        if let maxElement = component.components.map({ [findMaxDepthForComponent($0)] }).reduce([Int](), combine: { $0 + $1 }).maxElement() {
+        let depths = component.components.map { findMaxDepthForComponent($0) }
+        if let maxElement = depths.maxElement() {
             return maxElement + 1
         }
         


### PR DESCRIPTION
To test the changes, compile the project using `xcodebuild -scheme Taylor clean build OTHER_SWIFT_FLAGS="-D DEBUG -Xfrontend -debug-time-function-bodies"| grep "[1-9].[0-9]ms" | sort -nr` before and after this patch.  
This will give you a list of functions that take the most time to be compiled. The slowest functions will be on the top of the list.  
You can also use `xctool clean build` and compare the total times to build the project.
