### PR TITLE
Add 'MAKE_SYMLINKS' option to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 TEMPORARY_FOLDER?=$(HOME)/tmp
 PREFIX?=/usr/local/tools/Taylor
+MAKE_SYMLINKS?=yes
 BUILD_TOOL?=xcodebuild
 PACKAGE_NAME?=Taylor.app
 BUILD_DESTINATION?=$(TEMPORARY_FOLDER)/Build/Products/Release
@@ -16,8 +17,10 @@ install:
 
 	ditto "$(BUILD_DESTINATION)/$(PACKAGE_NAME)/Contents/MacOS/Taylor" "$(PREFIX)/bin/taylor"
 	ditto "$(BUILD_DESTINATION)/$(PACKAGE_NAME)/Contents/Frameworks/" "$(PREFIX)/Frameworks/"
+ifeq ($(MAKE_SYMLINKS),yes)
 	ln -sf "$(PREFIX)/bin/taylor" "/usr/local/bin/taylor"
-	
+endif
+
 	make remove
 
 remove:


### PR DESCRIPTION
This option will be used to deactivate symlinks creation when `make install` is called from Homebrew formula. Executing `ln -s` in Homebrew formula breaks the sandbox.
