### PR TITLE
Slightly change rules warning messages

### DIFF
--- a/TaylorFramework/Modules/temper/Rules/CyclomaticComplexityRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/CyclomaticComplexityRule.swift
@@ -25,7 +25,7 @@ final class CyclomaticComplexityRule : Rule {
         }
     }
     private let decisionalComponentTypes = [ComponentType.If, .While, .For, .Case, .ElseIf, .Ternary, .NilCoalescing, .Guard]
-    
+
     func checkComponent(component: Component) -> Result {
         if component.type != ComponentType.Function { return (true, nil, nil) }
         let complexity = findComplexityForComponent(component) + 1
@@ -36,11 +36,11 @@ final class CyclomaticComplexityRule : Rule {
         }
         return (true, nil, complexity)
     }
-    
+
     func formatMessage(name: String, value: Int) -> String {
-        return "The method '\(name)' has a Cyclomatic Complexity of \(value). The configured cyclomatic complexity is \(limit)"
+        return "The method '\(name)' has a Cyclomatic Complexity of \(value). The allowed Cyclomatic Complexity is \(limit)"
     }
-    
+
     private func findComplexityForComponent(component: Component) -> Int {
         let complexity = decisionalComponentTypes.contains(component.type) ? 1 : 0
         return component.components.map({ findComplexityForComponent($0) }).reduce(complexity, combine: +)

--- a/TaylorFramework/Modules/temper/Rules/ExcessiveParameterListRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/ExcessiveParameterListRule.swift
@@ -34,11 +34,11 @@ final class ExcessiveParameterListRule : Rule {
         }
         return (true , nil, parametersCount)
     }
-    
+
     func formatMessage(name: String, value: Int) -> String {
-        return "Method '\(name)' has \(value) parameters. The configured number of parameters is \(limit)"
+        return "Method '\(name)' has \(value) parameters. The allowed number of parameters is \(limit)"
     }
-    
+
     private func parametersCountForFunction(component: Component) -> Int {
         return component.components.filter { $0.type == ComponentType.Parameter }.count
     }

--- a/TaylorFramework/Modules/temper/Rules/NPathComplexityRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NPathComplexityRule.swift
@@ -24,7 +24,7 @@ final class NPathComplexityRule : Rule {
             }
         }
     }
-    
+
     func checkComponent(component: Component) -> Result {
         if component.type != ComponentType.Function { return (true, nil, nil) }
         let complexity = component.rangeNPathComplexity()
@@ -35,22 +35,22 @@ final class NPathComplexityRule : Rule {
         }
         return (true , nil, complexity)
     }
-    
+
     func formatMessage(name: String, value: Int) -> String {
-        return "Method '\(name)' has a NPath Complexity of \(value). The configured NPath Complexity is \(limit)"
+        return "Method '\(name)' has a NPath Complexity of \(value). The allowed NPath Complexity is \(limit)"
     }
 }
 
 extension Component {
-    
+
     func expressionNPath() -> Int {
         return components.filter { $0.type == ComponentType.Or || $0.type == ComponentType.And }.count
     }
-    
+
     func NPathComplexity() -> Int {
         return type.NPathComplexityForComponent(self)
     }
-    
+
     func rangeNPathComplexity() -> Int {
         if type == .Switch {
             return components.map({ $0.NPathComplexity() }).reduce(0, combine: +)
@@ -60,7 +60,7 @@ extension Component {
         let complexities = filteredComponents.map { $0.NPathComplexity() }
         return complexities.reduce(1, combine: *)
     }
-    
+
     func NPathForIfComponent() -> Int {
         if let nextComponent = nextComponent() where
             nextComponent.type == .Else || nextComponent.type == .ElseIf {
@@ -68,7 +68,7 @@ extension Component {
         }
         return 1 + expressionNPath() + rangeNPathComplexity()
     }
-    
+
     func NPathForElseIfComponent() -> Int {
         var complexity = expressionNPath() + rangeNPathComplexity()
         if let nextComponent = nextComponent() {
@@ -82,16 +82,16 @@ extension Component {
 
 
 extension ComponentType {
-    
+
     var hasRange: Bool {
         return [ComponentType.Repeat, .While, .For, .Else, .Case, .Brace, .Switch].contains(self)
     }
-    
+
     func NPathComplexityForComponent(component: Component) -> Int {
         if component.type.hasRange { return NPathForRangeComponent(component) }
         return NPathForNonRangeComponent(component)
     }
-    
+
     private func NPathForRangeComponent(component: Component) -> Int {
         switch component.type {
         case .Repeat, .While, .For: return 1 + component.rangeNPathComplexity() + component.expressionNPath()
@@ -100,7 +100,7 @@ extension ComponentType {
         default: return 0
         }
     }
-    
+
     private  func NPathForNonRangeComponent(component: Component) -> Int {
         switch component.type {
         case .If, .Guard: return component.NPathForIfComponent()

--- a/TaylorFramework/Modules/temper/Rules/NestedBlockDepthRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NestedBlockDepthRule.swift
@@ -25,7 +25,7 @@ final class NestedBlockDepthRule : Rule {
             }
         }
     }
-    
+
     func checkComponent(component: Component) -> Result {
         if component.type != ComponentType.Function { return (true, nil, nil) }
         let depth = findMaxDepthForComponent(component)
@@ -34,30 +34,29 @@ final class NestedBlockDepthRule : Rule {
             let message = formatMessage(name, value: depth)
             return (false, message, depth)
         }
-        
+
         return (true, nil, depth)
     }
-    
+
     func formatMessage(name: String, value: Int) -> String {
-        return "Method '\(name)' has a block depth of \(value). The configured block depth is \(limit)"
+        return "Method '\(name)' has a block depth of \(value). The allowed block depth is \(limit)"
     }
-    
+
     private func findMaxDepthForComponent(component: Component) -> Int {
         if !checkForAdmisibleComponents(component.components) || component.components.count == 0 {
             return 0
         }
-        
         let depths = component.components.map { findMaxDepthForComponent($0) }
         if let maxElement = depths.maxElement() {
             return maxElement + 1
         }
-        
+
         return 0
     }
-    
+
     private func checkForAdmisibleComponents(components: [Component]) -> Bool {
         let commonTypes = Set(components.map({ $0.type })).intersect(Set(admissibleComponents))
-        
+
         return !commonTypes.isEmpty
     }
 }

--- a/TaylorFramework/Modules/temper/Rules/NumberOfLinesInClassRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NumberOfLinesInClassRule.swift
@@ -25,7 +25,7 @@ final class NumberOfLinesInClassRule : Rule {
         }
     }
     private var linesCount = 0
-    
+
     func checkComponent(component: Component) -> Result {
         if component.type != ComponentType.Class { return (true, nil, nil) }
         linesCount = component.range.length
@@ -35,12 +35,12 @@ final class NumberOfLinesInClassRule : Rule {
             let message = formatMessage(name, value: linesCount)
             return (false, message, linesCount)
         }
-        
+
         return (true, nil, linesCount)
     }
-    
+
     func formatMessage(name: String, value: Int) -> String {
-        return "Class '\(name)' has to many lines: \(value). The configured number of lines in class is \(limit)"
+        return "Class '\(name)' has too many lines: \(value). The allowed number of lines in a class is \(limit)"
     }
 
     private func deleteLinesFromComponent(component: Component) {

--- a/TaylorFramework/Modules/temper/Rules/NumberOfLinesInMethodRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NumberOfLinesInMethodRule.swift
@@ -25,7 +25,7 @@ final class NumberOfLinesInMethodRule : Rule {
         }
     }
     private var linesCount = 0
-    
+
     func checkComponent(component: Component) -> Result {
         if component.type != ComponentType.Function { return (true, nil, nil) }
         linesCount = component.range.length
@@ -35,14 +35,14 @@ final class NumberOfLinesInMethodRule : Rule {
             let message = formatMessage(name, value: linesCount)
             return (false, message, linesCount)
         }
-        
+
         return (true, nil, linesCount)
     }
-    
+
     func formatMessage(name: String, value: Int) -> String {
-        return "Method '\(name)' has to many lines: \(value). The configured number of lines in method is \(limit)"
+        return "Method '\(name)' has too many lines: \(value). The allowed number of lines in a method is \(limit)"
     }
-    
+
     private func deleteLinesFromComponent(component: Component) {
         let _ = component.components.map({ (component: Component) -> Void in
             if component.isRedundantLine {

--- a/TaylorFramework/Modules/temper/Rules/NumberOfMethodsInClassRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NumberOfMethodsInClassRule.swift
@@ -24,7 +24,7 @@ final class NumberOfMethodsInClassRule : Rule {
             }
         }
     }
-    
+
     func checkComponent(component: Component) -> Result {
         if component.type != ComponentType.Class { return (true, nil, nil) }
         let methodsCount = getMethodsCountForComponent(component)
@@ -36,11 +36,11 @@ final class NumberOfMethodsInClassRule : Rule {
 
         return (true, nil, methodsCount)
     }
-    
+
     func formatMessage(name: String, value: Int) -> String {
-        return "Class '\(name)' has to many methods: \(value). The configured number of methods in class is \(limit)"
+        return "Class '\(name)' has too many methods: \(value). The allowed number of methods in class is \(limit)"
     }
-    
+
     private func getMethodsCountForComponent(component: Component) -> Int {
         return component.components.filter({ $0.type == ComponentType.Function }).count
     }


### PR DESCRIPTION
This commit comes with an improvement of warning messages by:
- Fix typos in excessive length rules by changing `to many` to
  `too many`.
- Change 'configured' to 'allowed', removing the implicit meaning
  of a framework configured limit values for rules.
- Make `Cyclomatic Complexity` case removing the inconsistency
  with `NPath Complexity` which was already case.
