### PR TITLE
Slightly change rules warning messages

### DIFF
--- a/TaylorFramework/Modules/temper/Rules/CyclomaticComplexityRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/CyclomaticComplexityRule.swift
@@ -38,7 +38,7 @@ final class CyclomaticComplexityRule : Rule {
     }
     
     func formatMessage(name: String, value: Int) -> String {
-        return "The method '\(name)' has a Cyclomatic Complexity of \(value). The configured cyclomatic complexity is \(limit)"
+        return "The method '\(name)' has a Cyclomatic Complexity of \(value). The allowed Cyclomatic Complexity is \(limit)"
     }
     
     private func findComplexityForComponent(component: Component) -> Int {

--- a/TaylorFramework/Modules/temper/Rules/ExcessiveParameterListRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/ExcessiveParameterListRule.swift
@@ -36,7 +36,7 @@ final class ExcessiveParameterListRule : Rule {
     }
     
     func formatMessage(name: String, value: Int) -> String {
-        return "Method '\(name)' has \(value) parameters. The configured number of parameters is \(limit)"
+        return "Method '\(name)' has \(value) parameters. The allowed number of parameters is \(limit)"
     }
     
     private func parametersCountForFunction(component: Component) -> Int {

--- a/TaylorFramework/Modules/temper/Rules/NPathComplexityRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NPathComplexityRule.swift
@@ -37,7 +37,7 @@ final class NPathComplexityRule : Rule {
     }
     
     func formatMessage(name: String, value: Int) -> String {
-        return "Method '\(name)' has a NPath Complexity of \(value). The configured NPath Complexity is \(limit)"
+        return "Method '\(name)' has a NPath Complexity of \(value). The allowed NPath Complexity is \(limit)"
     }
 }
 

--- a/TaylorFramework/Modules/temper/Rules/NestedBlockDepthRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NestedBlockDepthRule.swift
@@ -39,7 +39,7 @@ final class NestedBlockDepthRule : Rule {
     }
     
     func formatMessage(name: String, value: Int) -> String {
-        return "Method '\(name)' has a block depth of \(value). The configured block depth is \(limit)"
+        return "Method '\(name)' has a block depth of \(value). The allowed block depth is \(limit)"
     }
     
     private func findMaxDepthForComponent(component: Component) -> Int {

--- a/TaylorFramework/Modules/temper/Rules/NumberOfLinesInClassRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NumberOfLinesInClassRule.swift
@@ -40,7 +40,7 @@ final class NumberOfLinesInClassRule : Rule {
     }
     
     func formatMessage(name: String, value: Int) -> String {
-        return "Class '\(name)' has to many lines: \(value). The configured number of lines in class is \(limit)"
+        return "Class '\(name)' has too many lines: \(value). The allowed number of lines in a class is \(limit)"
     }
 
     private func deleteLinesFromComponent(component: Component) {

--- a/TaylorFramework/Modules/temper/Rules/NumberOfLinesInMethodRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NumberOfLinesInMethodRule.swift
@@ -40,7 +40,7 @@ final class NumberOfLinesInMethodRule : Rule {
     }
     
     func formatMessage(name: String, value: Int) -> String {
-        return "Method '\(name)' has to many lines: \(value). The configured number of lines in method is \(limit)"
+        return "Method '\(name)' has too many lines: \(value). The allowed number of lines in a method is \(limit)"
     }
     
     private func deleteLinesFromComponent(component: Component) {

--- a/TaylorFramework/Modules/temper/Rules/NumberOfMethodsInClassRule.swift
+++ b/TaylorFramework/Modules/temper/Rules/NumberOfMethodsInClassRule.swift
@@ -33,12 +33,12 @@ final class NumberOfMethodsInClassRule : Rule {
             let message = formatMessage(name, value: methodsCount)
             return (false, message, methodsCount)
         }
-
+        
         return (true, nil, methodsCount)
     }
     
     func formatMessage(name: String, value: Int) -> String {
-        return "Class '\(name)' has to many methods: \(value). The configured number of methods in class is \(limit)"
+        return "Class '\(name)' has too many methods: \(value). The allowed number of methods in class is \(limit)"
     }
     
     private func getMethodsCountForComponent(component: Component) -> Int {


### PR DESCRIPTION
This commit comes with an improvement of warning messages by:
- Fix typos in excessive length rules by changing `to many` to
  `too many`.
- Change 'configured' to 'allowed', removing the implicit meaning
  of a framework configured limit values for rules.
- Make `Cyclomatic Complexity` case removing the inconsistency
  with `NPath Complexity` which was already case.
