### PR TITLE
Handle erroneous arguments

### DIFF
--- a/TaylorFramework/Modules/EasterEggs/PacmanRunner.swift
+++ b/TaylorFramework/Modules/EasterEggs/PacmanRunner.swift
@@ -34,7 +34,7 @@ class PacmanRunner {
     func input() -> String {
         let keyboard = NSFileHandle.fileHandleWithStandardInput()
         let inputData = keyboard.availableData
-        return (NSString(data: inputData, encoding: NSUTF8StringEncoding) ?? "") as String
+        return String(String(data: inputData, encoding: NSUTF8StringEncoding)?.characters.first ?? Character(""))
     }
     
     func runEasterEgg(paths: [Path]) {

--- a/TaylorFramework/Modules/caprices/ProccessingMessage/MessageProcessor.swift
+++ b/TaylorFramework/Modules/caprices/ProccessingMessage/MessageProcessor.swift
@@ -24,10 +24,10 @@ class MessageProcessor {
     
     let optionsProcessor = OptionsProcessor()
     
-    func processArguments(arguments:[String]) -> Options {
+    func processArguments(arguments:[String]) throws -> Options {
         guard arguments.count > 1 else { return defaultResultDictionary() }
         
-        return processMultipleArguments(arguments)
+        return try processMultipleArguments(arguments)
     }
     
     
@@ -39,9 +39,9 @@ class MessageProcessor {
     }
     
     
-    func processMultipleArguments(arguments:[String]) -> Options {
+    func processMultipleArguments(arguments:[String]) throws -> Options {
         if arguments.count.isOdd {
-            return optionsProcessor.processOptions(arguments)
+            return try optionsProcessor.processOptions(arguments)
         } else if arguments.containFlags {
             FlagBuilder().flag(arguments.second!).execute() //Safe to force unwrap
             exit(0)

--- a/TaylorFramework/Modules/caprices/PublicInterface/Caprice.swift
+++ b/TaylorFramework/Modules/caprices/PublicInterface/Caprice.swift
@@ -30,8 +30,8 @@ struct Caprice {
     Retuns empty dictionary if help is requested.
     Returns dictionary with error key if an error occurs.
     */
-    func processArguments(arguments: [String]) -> Options {
-        let resultDictionary = messageProcessor.processArguments(arguments)
+    func processArguments(arguments: [String]) throws -> Options {
+        let resultDictionary = try messageProcessor.processArguments(arguments)
         return checkIfErrorOccursOrHelpRequested(resultDictionary)
     }
     

--- a/TaylorFramework/Taylor/Arguments.swift
+++ b/TaylorFramework/Taylor/Arguments.swift
@@ -12,8 +12,8 @@ struct Arguments {
     let caprice = Caprice()
     let arguments: Options
     
-    init () {
-        arguments = caprice.processArguments(Process.arguments)
+    init () throws {
+        arguments = try caprice.processArguments(Process.arguments)
     }
     
     var finderParameters: Options {

--- a/TaylorFramework/Taylor/Taylor.swift
+++ b/TaylorFramework/Taylor/Taylor.swift
@@ -9,43 +9,61 @@
 import Foundation
 
 public struct Taylor {
-    let arguments = Arguments()
-    let printer: Printer
     
-    public init() {
-        printer = Printer(verbosityLevel: arguments.verbosityLevel)
-    }
+    public init() { }
     
     /**
      Runs Taylor which initializes all other modules.
     */
     public func run() {
+        guard let arguments = processArguments() else { return }
+        if arguments.arguments.isEmpty || arguments.arguments[ErrorKey] != nil {
+            handleError("Invalid arguments.")
+            return
+        }
+        let printer = Printer(verbosityLevel: arguments.verbosityLevel)
         guard let rootPath = arguments.rootPath else {
             printer.printError("No path received.");
             return
         }
-        if inputArgumentsErrorCommited(arguments.arguments) {
-            PacmanRunner().runEasterEggPrompt()
-        }
         printer.printInfo("Output directory: \(rootPath)")
         
-        generateTimeReport(rootPath)
+        generateTimeReport(rootPath, printer: printer, arguments: arguments)
     }
     
-    func generateTimeReport(rootPath: String) {
+    func processArguments() -> Arguments? {
+        do { return try Arguments() }
+        catch CommandLineError.InvalidArguments(let errorMessage) {
+            handleError(errorMessage)
+        } catch CommandLineError.InvalidInformationalOption(let errorMessage) {
+            handleError(errorMessage)
+        } catch CommandLineError.InvalidOption(let errorMessage) {
+            handleError(errorMessage)
+        } catch CommandLineError.AbuseOfOptions(let errorMessage) {
+            handleError(errorMessage)
+        } catch { }
+        return nil
+    }
+    
+    func handleError(errorMessage: String) {
+        print(errorMessage)
+        PacmanRunner().runEasterEggPrompt()
+    }
+    
+    func generateTimeReport(rootPath: String, printer: Printer, arguments: Arguments) {
         let timer = Timer()
         timer.start()
-        generateReportOnPath(rootPath)
+        generateReportOnPath(rootPath, arguments: arguments, printer: printer)
         printer.printInfo("Running time: \(timer.stop())")
     }
     
-    func generateReportOnPath(path:Path) {
-        let fileContents = getFileContents()
+    func generateReportOnPath(path: Path, arguments: Arguments, printer: Printer) {
+        let fileContents = getFileContents(arguments)
         let reportGenerator = ReportGenerator(arguments: arguments, printer: printer)
         reportGenerator.generateReport(path, fileContents: fileContents)
     }
     
-    func getFileContents() -> [FileContent] {
+    func getFileContents(arguments: Arguments) -> [FileContent] {
         let paths = Finder().findFilePaths(parameters: arguments.finderParameters)
         
         return parallelizeTokenization(paths)
@@ -55,9 +73,4 @@ public struct Taylor {
         let scissors = Scissors()
         return paths.pmap { scissors.tokenizeFileAtPath($0) }
     }
-    
-    func inputArgumentsErrorCommited(arguments: Options) -> Bool {
-        return arguments[ErrorKey] != nil
-    }
-    
 }

--- a/TaylorFrameworkTests/CapriceTests/Mocks/MockMessageProcessor.swift
+++ b/TaylorFrameworkTests/CapriceTests/Mocks/MockMessageProcessor.swift
@@ -42,7 +42,7 @@ class MockMessageProcessor : MessageProcessor {
         
         if arguments.count.isOdd {
             let optionsProcessor = MockOptionsProcessor()
-            return optionsProcessor.processOptions(arguments)
+            return try! optionsProcessor.processOptions(arguments) // We want this to crash here if arguments are invalid
         } else if arguments.containFlags {
             FlagBuilder().flag(arguments.second!).execute()
             return [FlagKey : [FlagKeyValue]]

--- a/TaylorFrameworkTests/CapriceTests/Tests/CapriceTests.swift
+++ b/TaylorFrameworkTests/CapriceTests/Tests/CapriceTests.swift
@@ -16,6 +16,10 @@ class CapriceTests: QuickSpec {
             let currentPath = NSFileManager.defaultManager().currentDirectoryPath
             var caprice : Caprice!
             
+            func forceProcessArguments(options: [String]) -> Options {
+                return try! caprice.processArguments(options)
+            }
+            
             beforeEach {
                 caprice = Caprice()
             }
@@ -28,24 +32,24 @@ class CapriceTests: QuickSpec {
                 
                 it("should set default values for dictionary (no excludesFile)") {
                     let inputArguments = [currentPath]
-                    expect(caprice.processArguments(inputArguments)).to(equal([ResultDictionaryPathKey : [currentPath], ResultDictionaryTypeKey : [DefaultExtensionType]]))
+                    expect(forceProcessArguments(inputArguments)).to(equal([ResultDictionaryPathKey : [currentPath], ResultDictionaryTypeKey : [DefaultExtensionType]]))
                 }
                 
                 it("should return default verbosity") {
                     let inputArguments = [currentPath]
-                    caprice.processArguments(inputArguments)
+                    forceProcessArguments(inputArguments)
                     expect(caprice.getVerbosityLevel()).to(equal(VerbosityLevel.Error))
                 }
                 
                 it("should return empty array of reporters") {
                     let inputArguments = [currentPath]
-                    caprice.processArguments(inputArguments)
+                    forceProcessArguments(inputArguments)
                     expect(caprice.getReporters()).to(beEmpty())
                 }
                 
                 it("should return empty array of reporters") {
                     let inputArguments = [currentPath]
-                    caprice.processArguments(inputArguments)
+                    forceProcessArguments(inputArguments)
                     expect(caprice.getRuleThresholds()).to(beEmpty())
                 }
                 
@@ -55,7 +59,7 @@ class CapriceTests: QuickSpec {
                 
                 it("should return an empty dictionary") {
                     let inputArguments = [currentPath, FlagKey]
-                    caprice.processArguments(inputArguments)
+                    forceProcessArguments(inputArguments)
                     expect(caprice.getRuleThresholds()).to(beEmpty())
                 }
                 
@@ -65,7 +69,7 @@ class CapriceTests: QuickSpec {
                 
                 it("should return them using getReporters function") {
                     let inputArguments = [currentPath, ReporterLong, "plain:/path/to/plain.txt"]
-                    caprice.processArguments(inputArguments)
+                    forceProcessArguments(inputArguments)
                     expect(caprice.getReporters()).to(equal([["type" : "plain", "fileName" : "/path/to/plain.txt"]]))
                 }
                 
@@ -75,7 +79,7 @@ class CapriceTests: QuickSpec {
                 
                 it("should return them using getRuleThresholds function") {
                     let inputArguments = [currentPath, RuleCustomizationLong, "ExcessiveMethodLength=10"]
-                    caprice.processArguments(inputArguments)
+                    forceProcessArguments(inputArguments)
                     expect(caprice.getRuleThresholds()).to(equal(["ExcessiveMethodLength" : 10]))
                 }
                 
@@ -85,7 +89,7 @@ class CapriceTests: QuickSpec {
                 
                 it("should return it using getVerbosityLevel function") {
                     let inputArguments = [currentPath, VerbosityLong, VerbosityLevelInfo]
-                    caprice.processArguments(inputArguments)
+                    forceProcessArguments(inputArguments)
                     expect(caprice.getVerbosityLevel()).to(equal(VerbosityLevel.Info))
                 }
                 
@@ -100,7 +104,7 @@ class CapriceTests: QuickSpec {
                     let fileArg = "fileArg"
                     let typeArg = "someType"
                     let inputArguments = [currentPath, PathLong, pathArg, ExcludeLong, excludeArg, FileLong, fileArg, TypeLong, typeArg, ReporterLong, "plain:/path/to/plain.txt", RuleCustomizationLong, "ExcessiveMethodLength=10", VerbosityLong, VerbosityLevelWarning]
-                    let resultDictionary = localCaprice.processArguments(inputArguments)
+                    let resultDictionary = try! localCaprice.processArguments(inputArguments)
                     expect(resultDictionary).to(equal([ResultDictionaryPathKey : [pathArg], ResultDictionaryExcludesKey : [pathArg + "/" + excludeArg], ResultDictionaryFileKey : [pathArg + "/" + fileArg], ResultDictionaryTypeKey : ["someType"]]))
                     expect(localCaprice.getVerbosityLevel()).to(equal(VerbosityLevel.Warning))
                     expect(localCaprice.getReporters()).to(equal([["type" : "plain", "fileName" : "/path/to/plain.txt"]]))
@@ -118,7 +122,7 @@ class CapriceTests: QuickSpec {
                     let fileArg = "fileArg"
                     let typeArg = "someType"
                     let inputArguments = [currentPath, PathLong, pathArg, ExcludeLong, excludeArg, FileLong, fileArg, TypeLong, typeArg, ReporterLong, "invalidReporter", RuleCustomizationLong, "ExcessiveMethodLength=10", VerbosityLong, VerbosityLevelWarning]
-                    let resultDictionary = localCaprice.processArguments(inputArguments)
+                    let resultDictionary = try! localCaprice.processArguments(inputArguments)
                     expect(resultDictionary).to(equal([ErrorKey: [""]]))
                     expect(localCaprice.getVerbosityLevel()).to(equal(VerbosityLevel.Error))
                     expect(localCaprice.getReporters()).to(beEmpty())
@@ -129,7 +133,7 @@ class CapriceTests: QuickSpec {
             
             it("should return error dictionary if error occures") {
                 let inputArguments = [currentPath, ExcludesFileLong, "errorFile.txt"]
-                expect(caprice.processArguments(inputArguments)).to(equal([ErrorKey: [""]]))
+                expect(forceProcessArguments(inputArguments)).to(equal([ErrorKey: [""]]))
             }
             
         }

--- a/TaylorFrameworkTests/CapriceTests/Tests/MessageProcessorTests.swift
+++ b/TaylorFrameworkTests/CapriceTests/Tests/MessageProcessorTests.swift
@@ -16,6 +16,10 @@ class MessageProcessorTests: QuickSpec {
             var messageProcessor : MessageProcessor!
             let currentPath = NSFileManager.defaultManager().currentDirectoryPath
             
+            func forceProcessArguments(options: [String]) -> Options {
+                return try! messageProcessor.processArguments(options)
+            }
+            
             beforeEach {
                 messageProcessor = MessageProcessor()
             }
@@ -26,21 +30,21 @@ class MessageProcessorTests: QuickSpec {
             
             it("should return current path and type for empty arguments, excludes file does not exists so excludes are not setted") {
                 let inputArguments = [currentPath]
-                expect(messageProcessor.processArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : ["swift"]]))
+                expect(forceProcessArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : ["swift"]]))
             }
             
             it("should return empty dictionary for invalid number of arguments") {
                 let inputArguments = [currentPath, "someArgument"]
-                expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
+                expect(forceProcessArguments(inputArguments)).to(beEmpty())
             }
             
             it("should replace default path if path is indicated") {
                 let pathArgument = "somePath"
                 var inputArguments = [currentPath, PathLong, pathArgument]
                 let absolutePath = currentPath + "/" + pathArgument
-                expect(messageProcessor.processArguments(inputArguments)).to(equal(["path" : [absolutePath], "type" : ["swift"]]))
+                expect(forceProcessArguments(inputArguments)).to(equal(["path" : [absolutePath], "type" : ["swift"]]))
                 inputArguments = [currentPath, PathShort, pathArgument]
-                expect(messageProcessor.processArguments(inputArguments)).to(equal(["path" : [absolutePath], "type" : ["swift"]]))
+                expect(forceProcessArguments(inputArguments)).to(equal(["path" : [absolutePath], "type" : ["swift"]]))
             }
             
             it("should set path and type if they are indicated") {
@@ -48,55 +52,55 @@ class MessageProcessorTests: QuickSpec {
                 let typeArgument = "someType"
                 let inputArguments = [currentPath, PathLong, pathArgument, TypeLong, typeArgument]
                 let absolutePath = currentPath + "/" + pathArgument
-                expect(messageProcessor.processArguments(inputArguments)).to(equal(["path" : [absolutePath], "type" : [typeArgument]]))
+                expect(forceProcessArguments(inputArguments)).to(equal(["path" : [absolutePath], "type" : [typeArgument]]))
             }
             
             it("should persist default path if only type is indicated") {
                 let typeArgument = "someType"
                 var inputArguments = [currentPath, TypeLong, typeArgument]
-                expect(messageProcessor.processArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : [typeArgument]]))
+                expect(forceProcessArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : [typeArgument]]))
                 inputArguments = [currentPath, TypeShort, typeArgument]
-                expect(messageProcessor.processArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : [typeArgument]]))
+                expect(forceProcessArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : [typeArgument]]))
             }
             
             it("should add files") {
                 let fileArgument = "someFile"
                 let inputArguments = [currentPath, FileLong, fileArgument, FileShort, fileArgument]
                 let absolutePathToFile = currentPath + "/" + fileArgument
-                expect(messageProcessor.processArguments(inputArguments)).to(equal(["path" : [currentPath], "files" : [absolutePathToFile, absolutePathToFile], "type" : ["swift"]]))
+                expect(forceProcessArguments(inputArguments)).to(equal(["path" : [currentPath], "files" : [absolutePathToFile, absolutePathToFile], "type" : ["swift"]]))
             }
             
             it("should add exclude paths") {
                 let excludeArgument = "someExcludePath"
                 let inputArguments = [currentPath, ExcludeLong, excludeArgument, ExcludeShort, excludeArgument]
                 let absolutePathToExclude = currentPath + "/" + excludeArgument
-                expect(messageProcessor.processArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : ["swift"], "excludes" : [absolutePathToExclude, absolutePathToExclude]]))
+                expect(forceProcessArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : ["swift"], "excludes" : [absolutePathToExclude, absolutePathToExclude]]))
             }
             
-            it("should return empty dictionary if option does not contain prefix") {
+            it("should throw if option does not contain prefix") {
                 let invalidOption = "path"
                 let somePath = "somePath"
                 let inputArguments = [currentPath, invalidOption, somePath]
-                expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
+                expect(try? messageProcessor.processArguments(inputArguments)).to(beNil())
             }
             
-            it("should return empty dictionary if arguments contain an invalid option with prefix") {
+            it("should throw if arguments contain an invalid option with prefix") {
                 let invalidOption = "-path"
                 let somePath = "somePath"
                 let inputArguments = [currentPath, invalidOption, somePath]
-                expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
+                expect(try? messageProcessor.processArguments(inputArguments)).to(beNil())
             }
             
             it("should return empty dictionary if multiple paths are indicated") {
                 let somePath = "somePath"
                 let inputArguments = [currentPath, PathLong, somePath, PathLong, somePath]
-                expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
+                expect(forceProcessArguments(inputArguments)).to(beEmpty())
             }
             
             it("should return empty dictionary if multiple types are indicated") {
                 let someType = "someType"
                 let inputArguments = [currentPath, TypeLong, someType, TypeLong, someType]
-                expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
+                expect(forceProcessArguments(inputArguments)).to(beEmpty())
             }
             
             it("should early return if dictionary has no path key") {
@@ -111,14 +115,14 @@ class MessageProcessorTests: QuickSpec {
                 it("should return same exclude argument if it have .* prefix and sufix") {
                     let excludeArgument = ".*someExcludeFile.*"
                     let inputArguments = [currentPath, ExcludeLong, excludeArgument, ExcludeShort, excludeArgument]
-                    expect(messageProcessor.processArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : ["swift"], "excludes" : [excludeArgument, excludeArgument]]))
+                    expect(forceProcessArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : ["swift"], "excludes" : [excludeArgument, excludeArgument]]))
                 }
                 
                 it("should return empty dictioanry if excludes path contains .* prefix or sufix") {
                     let excludePath = ".*somePath"
                     let excludePath1 = "somePath.*"
                     let inputArguments = [currentPath, ExcludeShort, excludePath, ExcludeLong, excludePath1]
-                    expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
+                    expect(forceProcessArguments(inputArguments)).to(beEmpty())
                 }
                 
             }
@@ -132,14 +136,14 @@ class MessageProcessorTests: QuickSpec {
                 it("should return empty dictionary if multiple excludesFiles was indicated") {
                     let somePath = "somePath"
                     let inputArguments = [currentPath, ExcludesFileLong, somePath, ExcludesFileShort, somePath]
-                    expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
+                    expect(forceProcessArguments(inputArguments)).to(beEmpty())
                 }
                 
                 it("default excludes file must be read and set to result dictionary if it exists, in plus at default path and type") {
                     let mockMessageProcessor = MockMessageProcessor()
                     let inputArguments = [currentPath]
                     let resultsArrayOfExcludes = ["file.txt".formattedExcludePath(currentPath), "path/to/file.txt".formattedExcludePath(currentPath), "folder".formattedExcludePath(currentPath), "path/to/folder".formattedExcludePath(currentPath)]
-                    expect(mockMessageProcessor.processArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : ["swift"], "excludes" : resultsArrayOfExcludes]))
+                    expect(try! mockMessageProcessor.processArguments(inputArguments)).to(equal(["path" : [currentPath], "type" : ["swift"], "excludes" : resultsArrayOfExcludes]))
                 }
                 
                 it("should set exclude path and paths from excludeFile together") {
@@ -148,7 +152,7 @@ class MessageProcessorTests: QuickSpec {
                     let pathToExcludesFile = MockFileManager().testFile("excludes", fileType: "yml")
                     let resultsArrayOfExcludes = [somePath, "file.txt".formattedExcludePath(currentPath), "path/to/file.txt".formattedExcludePath(currentPath), "folder".formattedExcludePath(currentPath), "path/to/folder".formattedExcludePath(currentPath)]
                     let inputArguments = [currentPath, ExcludeLong, somePath, ExcludesFileLong, pathToExcludesFile]
-                    let dictionary = mockMessageProcessor.processArguments(inputArguments)
+                    let dictionary = try! mockMessageProcessor.processArguments(inputArguments)
                     expect(dictionary).to(equal(["path" : [currentPath], "type" : ["swift"], "excludes" : resultsArrayOfExcludes]))
                 }
                 
@@ -156,7 +160,7 @@ class MessageProcessorTests: QuickSpec {
                     let mockMessageProcessor = MockMessageProcessor()
                     let somePath = "somePath"
                     let inputArguments = [currentPath, PathShort, currentPath, ExcludeLong, somePath]
-                    let dictionary = mockMessageProcessor.processArguments(inputArguments)
+                    let dictionary = try! mockMessageProcessor.processArguments(inputArguments)
                     expect(dictionary).to(equal(["path" : [currentPath], "type" : ["swift"], "excludes" : [currentPath + "/" + somePath]]))
                 }
                 
@@ -167,11 +171,11 @@ class MessageProcessorTests: QuickSpec {
                 it("should return error dictionary if help file was not found") {
                     let mockMessageProcessor = MockMessageProcessor()
                     let inputArguments = [currentPath, FlagKey]
-                    expect(mockMessageProcessor.processArguments(inputArguments)).to(beEmpty())
+                    expect(try! mockMessageProcessor.processArguments(inputArguments)).to(beEmpty())
                 }
                 it("should return empty dictionary if single option is not help") {
                     let inputArguments = [currentPath, "errorOption"]
-                    expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
+                    expect(try! messageProcessor.processArguments(inputArguments)).to(beEmpty())
                 }
                 
             }
@@ -179,30 +183,30 @@ class MessageProcessorTests: QuickSpec {
             context("when getReporters is called") {
                 
                 it("should return an empty array if no reporters was passed as parameters") {
-                    messageProcessor.processArguments([currentPath])
+                    forceProcessArguments([currentPath])
                     expect(messageProcessor.getReporters()).to(beEmpty())
                 }
                 
                 it("should return array with specific dictionaries if reporter was passed") {
-                    messageProcessor.processArguments([currentPath, ReporterLong, "plain:/path/to/plain-output.txt"])
+                    forceProcessArguments([currentPath, ReporterLong, "plain:/path/to/plain-output.txt"])
                     expect(messageProcessor.getReporters()).to(equal([["type" : "plain", "fileName" : "/path/to/plain-output.txt"]]))
                 }
             }
             
             it("should return empty dictionary if invalid reporterOption was indicated") {
-                let resultDictionary = messageProcessor.processArguments([currentPath, ReporterLong, "plain/path/to/plain-output.txt"])
+                let resultDictionary = forceProcessArguments([currentPath, ReporterLong, "plain/path/to/plain-output.txt"])
                 expect(resultDictionary).to(beEmpty())
             }
             
             context("when getRuleThresholds is called") {
                 
                 it("shoul return an empty dictionary if no rules was indicated") {
-                    messageProcessor.processArguments([currentPath])
+                    forceProcessArguments([currentPath])
                     expect(messageProcessor.getRuleThresholds()).to(beEmpty())
                 }
                 
                 it("should return dictionary with rules if they were indicated") {
-                    messageProcessor.processArguments([currentPath, RuleCustomizationShort, "ExcessiveMethodLength=10"])
+                    forceProcessArguments([currentPath, RuleCustomizationShort, "ExcessiveMethodLength=10"])
                     expect(messageProcessor.getRuleThresholds()).to(equal(["ExcessiveMethodLength" : 10]))
                 }
                 
@@ -210,18 +214,18 @@ class MessageProcessorTests: QuickSpec {
             
             it("should return empty dictionary if invalid ruleCustomization was indicated") {
                 let inputArguments = [currentPath, RuleCustomizationShort, "ExcessiveMethodLength10"]
-                expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
+                expect(forceProcessArguments(inputArguments)).to(beEmpty())
             }
             
             context("when getVerbosityLevel is called") {
                 
                 it("should return default(error) verbosity if no verbosity was indicated") {
-                    messageProcessor.processArguments([currentPath])
+                    forceProcessArguments([currentPath])
                     expect(messageProcessor.getVerbosityLevel()).to(equal(VerbosityLevel.Error))
                 }
                 
                 it("should return rigth verbosity if that was indicated") {
-                    messageProcessor.processArguments([currentPath, VerbosityLong, "info"])
+                    forceProcessArguments([currentPath, VerbosityLong, "info"])
                     expect(messageProcessor.getVerbosityLevel()).to(equal(VerbosityLevel.Info))
                 }
                 
@@ -229,12 +233,12 @@ class MessageProcessorTests: QuickSpec {
             
             it("should return empty dictionary if invalid verbosity was indicated") {
                 let inputArguments = [currentPath, VerbosityShort, "errorArgument"]
-                expect(messageProcessor.processArguments(inputArguments)).to(beEmpty())
+                expect(forceProcessArguments(inputArguments)).to(beEmpty())
             }
             
             it("should append default excludes file to path from passed dictionary and not current path") {
                 let inputArguments = [currentPath, PathLong, "/somePath"]
-                let resultDiciotnary = messageProcessor.processArguments(inputArguments)
+                let resultDiciotnary = forceProcessArguments(inputArguments)
                 expect(messageProcessor.defaultExcludesFilePathForDictionary(resultDiciotnary)).to(equal("/somePath/excludes.yml"))
                 expect(messageProcessor.defaultExcludesFilePathForDictionary(resultDiciotnary)).toNot(equal(currentPath + "/excludes.yml"))
             }

--- a/TaylorFrameworkTests/CapriceTests/Tests/OptionsProcessorTests.swift
+++ b/TaylorFrameworkTests/CapriceTests/Tests/OptionsProcessorTests.swift
@@ -13,277 +13,282 @@ import Nimble
 class OptionsProcessorTests: QuickSpec {
     override func spec() {
         describe("OptionsProcessor") {
-            
-            let currentPath = NSFileManager.defaultManager().currentDirectoryPath
-            
-            var optionsProcessor : OptionsProcessor!
-                        
-            beforeEach {
-                optionsProcessor = OptionsProcessor()
-            }
-            
-            afterEach {
-                optionsProcessor = nil
-            }
-            
-            context("when arguments contain reporter option") {
+            do {
                 
-                it("should create ReporterOption and append it to reporterOptions array") {
-                    let reporterArgument = "plain:/path/to/plain-output.txt"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument]
-                    optionsProcessor.processOptions(inputArguments)
-                    let reporterArg = optionsProcessor.factory.filterClassesOfType(ReporterOption().name)[0].optionArgument
-                    let equal = (reporterArg == reporterArgument)
-                    expect(equal).to(beTrue())
+                let currentPath = NSFileManager.defaultManager().currentDirectoryPath
+                
+                var optionsProcessor : OptionsProcessor!
+                
+                func forceProcessOptions(options: [String]) -> Options {
+                    return try! optionsProcessor.processOptions(options)
                 }
                 
-                it("should return empty dictionary if reporter argument does not contain : symbol and is not xcode reporter") {
-                    let reporterArgument = "plain/path/to/plain-output.txt"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
+                beforeEach {
+                    optionsProcessor = OptionsProcessor()
                 }
                 
-                it("should return empty dictionary if reporter argument contain more than one : symbol") {
-                    let reporterArgument = "plain:/path/to/:plain-output.txt"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
+                afterEach {
+                    optionsProcessor = nil
                 }
                 
-                it("should return empty dictionary if reporters type doesn't match possible types") {
-                    let reporterArgument = "errorType:/path/to/plain-output.txt"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
-                }
-                
-                it("should not return empty dictionary(as when error occurs) when xcode is passed as argument for rule customization option") {
-                    let reporterArgument = "xcode"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).toNot(beEmpty())
-                }
-                
-            }
-            
-            context("when arguments contain multiple reporterOptions") {
-                
-                it("should append multiple reporterOptions to reporterOptions array") {
-                    let reporterArgument1 = "plain:/path/to/plain-output.txt"
-                    let reporterArgument2 = "json:/path/to/plain-output.json"
-                    let reporterArgument3 = "xcode"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument1, ReporterShort, reporterArgument2, ReporterShort, reporterArgument3]
-                    optionsProcessor.processOptions(inputArguments)
-                    var reportersArguments = [String]()
-                    for arg in optionsProcessor.factory.filterClassesOfType(ReporterOption().name) {
-                        reportersArguments.append(arg.optionArgument)
+                context("when arguments contain reporter option") {
+                    
+                    it("should create ReporterOption and append it to reporterOptions array") {
+                        let reporterArgument = "plain:/path/to/plain-output.txt"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument]
+                        forceProcessOptions(inputArguments)
+                        let reporterArg = optionsProcessor.factory.filterClassesOfType(ReporterOption().name)[0].optionArgument
+                        let equal = (reporterArg == reporterArgument)
+                        expect(equal).to(beTrue())
                     }
-                    let equal = (reportersArguments == [reporterArgument1, reporterArgument2, reporterArgument3])
-                    expect(equal).to(beTrue())
-                }
-                
-                it("should return empty dictionary if reportedOption type is repeated") {
-                    let reporterArgument = "plain:/path/to/plain-output.txt"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument, ReporterShort, reporterArgument]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
-                }
-                
-                it("should return empty dictionary if one of reportedOptions is not valid") {
-                    let reporterArgument1 = "plain:/path/to/plain-output.txt"
-                    let reporterArgument2 = "plain/path/to/plain-output.txt"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument1, ReporterShort, reporterArgument2]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
-                }
-                
-            }
-            
-            context("when valid reporterOptions indicated") {
-                
-                it("should set reporters property with dictionaries(type and fileName key)") {
-                    let reporterArgument = "plain:/path/to/plain-output.txt"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument]
-                    optionsProcessor.processOptions(inputArguments)
-                    expect(optionsProcessor.factory.getReporters()).to(equal([["type" : "plain", "fileName" : "/path/to/plain-output.txt"]]))
-                }
-                
-                it("should ser reporters property with type: xcode and fileName : EmptyString for xcode type reporter") {
-                    let reporterArgument = "xcode"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument]
-                    optionsProcessor.processOptions(inputArguments)
-                    expect(optionsProcessor.factory.getReporters()).to(equal([["type" : "xcode", "fileName" : ""]]))
-                }
-                
-                it("should set multiple reporters into array of dictionaries(type and fileName key)") {
-                    let reporterArgument = "plain:/path/to/plain-output.txt"
-                    let reporterArgument1 = "xcode"
-                    let inputArguments = [currentPath, ReporterLong, reporterArgument, ReporterLong, reporterArgument1]
-                    optionsProcessor.processOptions(inputArguments)
-                    expect(optionsProcessor.factory.getReporters()).to(equal([["type" : "plain", "fileName" : "/path/to/plain-output.txt"], ["type" : "xcode", "fileName" : ""]]))
-                }
-                
-            }
-            
-            context("when arguments contain rule customization option") {
-                
-                it("should create ruleCustomizationOption and append it to ruleCustomizationOptions array") {
-                    let rcArgument = "ExcessiveMethodLength=10"
-                    let inputArguments = [currentPath, RuleCustomizationLong, rcArgument]
-                    optionsProcessor.processOptions(inputArguments)
-                    let rcArguments = optionsProcessor.factory.filterClassesOfType(RuleCustomizationOption().name)[0].optionArgument
-                    let equal = (rcArgument == rcArguments)
-                    expect(equal).to(beTrue())
-                }
-                
-                it("should return empty dictionary if ruleCustommization argument does not contain = symbol") {
-                    let rcArgument = "ExcessiveMethodLength10"
-                    let inputArguments = [currentPath, RuleCustomizationShort, rcArgument]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
-                }
-                
-                it("should return empty dictionary if ruleCustommization argument contain more than one = symbol") {
-                    let rcArgument = "ExcessiveMethodLength=10=20"
-                    let inputArguments = [currentPath, RuleCustomizationShort, rcArgument]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
-                }
-                
-                it("should return empty dictionary if ruleCustommizations type doesn't match possible types") {
-                    let rcArgument = "SomeErrorCaseCustomization=10"
-                    let inputArguments = [currentPath, RuleCustomizationShort, rcArgument]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
-                }
-                
-                it("should return empty dictionary if argument for rule is not an integer") {
-                    let rcArgument = "SomeErrorCaseCustomization=1a0c"
-                    let inputArguments = [currentPath, RuleCustomizationShort, rcArgument]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
-                }
-                
-            }
-            
-            context("when arguments contain multiple customization rules") {
-                
-                it("should append multiple customization rules to ruleCustomizationOptions array") {
-                    let rcArgument1 = "ExcessiveMethodLength=10"
-                    let rcArgument2 = "ExcessiveClassLength=400"
-                    let inputArguments = [currentPath, RuleCustomizationLong, rcArgument1, RuleCustomizationShort, rcArgument2]
-                    optionsProcessor.processOptions(inputArguments)
-                    var rcArguments = [String]()
-                    for arg in optionsProcessor.factory.filterClassesOfType(RuleCustomizationOption().name) {
-                        rcArguments.append(arg.optionArgument)
+                    
+                    it("should return empty dictionary if reporter argument does not contain : symbol and is not xcode reporter") {
+                        let reporterArgument = "plain/path/to/plain-output.txt"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
                     }
-                    let equal = ([rcArgument1, rcArgument2] == rcArguments)
-                    expect(equal).to(beTrue())
+                    
+                    it("should return empty dictionary if reporter argument contain more than one : symbol") {
+                        let reporterArgument = "plain:/path/to/:plain-output.txt"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
+                    }
+                    
+                    it("should return empty dictionary if reporters type doesn't match possible types") {
+                        let reporterArgument = "errorType:/path/to/plain-output.txt"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
+                    }
+                    
+                    it("should not return empty dictionary(as when error occurs) when xcode is passed as argument for rule customization option") {
+                        let reporterArgument = "xcode"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).toNot(beEmpty())
+                    }
+                    
                 }
                 
-                it("should return empty dictionary if rule customization types are repeated") {
-                    let rcArgument = "ExcessiveMethodLength=10"
-                    let inputArguments = [currentPath, RuleCustomizationLong, rcArgument, RuleCustomizationShort, rcArgument]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
+                context("when arguments contain multiple reporterOptions") {
+                    
+                    it("should append multiple reporterOptions to reporterOptions array") {
+                        let reporterArgument1 = "plain:/path/to/plain-output.txt"
+                        let reporterArgument2 = "json:/path/to/plain-output.json"
+                        let reporterArgument3 = "xcode"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument1, ReporterShort, reporterArgument2, ReporterShort, reporterArgument3]
+                        forceProcessOptions(inputArguments)
+                        var reportersArguments = [String]()
+                        for arg in optionsProcessor.factory.filterClassesOfType(ReporterOption().name) {
+                            reportersArguments.append(arg.optionArgument)
+                        }
+                        let equal = (reportersArguments == [reporterArgument1, reporterArgument2, reporterArgument3])
+                        expect(equal).to(beTrue())
+                    }
+                    
+                    it("should return empty dictionary if reportedOption type is repeated") {
+                        let reporterArgument = "plain:/path/to/plain-output.txt"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument, ReporterShort, reporterArgument]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
+                    }
+                    
+                    it("should return empty dictionary if one of reportedOptions is not valid") {
+                        let reporterArgument1 = "plain:/path/to/plain-output.txt"
+                        let reporterArgument2 = "plain/path/to/plain-output.txt"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument1, ReporterShort, reporterArgument2]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
+                    }
+                    
                 }
                 
-                it("should return empty dictionary if one of rulesCustomizations is not valid") {
-                    let rcArgument1 = "ExcessiveMethodLength=10"
-                    let rcArgument2 = "ExcessiveClassLength400"
-                    let inputArguments = [currentPath, RuleCustomizationLong, rcArgument1, RuleCustomizationShort, rcArgument2]
-                    let resultDictionary = optionsProcessor.processOptions(inputArguments)
-                    expect(resultDictionary).to(beEmpty())
+                context("when valid reporterOptions indicated") {
+                    
+                    it("should set reporters property with dictionaries(type and fileName key)") {
+                        let reporterArgument = "plain:/path/to/plain-output.txt"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument]
+                        forceProcessOptions(inputArguments)
+                        expect(optionsProcessor.factory.getReporters()).to(equal([["type" : "plain", "fileName" : "/path/to/plain-output.txt"]]))
+                    }
+                    
+                    it("should ser reporters property with type: xcode and fileName : EmptyString for xcode type reporter") {
+                        let reporterArgument = "xcode"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument]
+                        forceProcessOptions(inputArguments)
+                        expect(optionsProcessor.factory.getReporters()).to(equal([["type" : "xcode", "fileName" : ""]]))
+                    }
+                    
+                    it("should set multiple reporters into array of dictionaries(type and fileName key)") {
+                        let reporterArgument = "plain:/path/to/plain-output.txt"
+                        let reporterArgument1 = "xcode"
+                        let inputArguments = [currentPath, ReporterLong, reporterArgument, ReporterLong, reporterArgument1]
+                        forceProcessOptions(inputArguments)
+                        expect(optionsProcessor.factory.getReporters()).to(equal([["type" : "plain", "fileName" : "/path/to/plain-output.txt"], ["type" : "xcode", "fileName" : ""]]))
+                    }
+                    
                 }
                 
+                context("when arguments contain rule customization option") {
+                    
+                    it("should create ruleCustomizationOption and append it to ruleCustomizationOptions array") {
+                        let rcArgument = "ExcessiveMethodLength=10"
+                        let inputArguments = [currentPath, RuleCustomizationLong, rcArgument]
+                        forceProcessOptions(inputArguments)
+                        let rcArguments = optionsProcessor.factory.filterClassesOfType(RuleCustomizationOption().name)[0].optionArgument
+                        let equal = (rcArgument == rcArguments)
+                        expect(equal).to(beTrue())
+                    }
+                    
+                    it("should return empty dictionary if ruleCustommization argument does not contain = symbol") {
+                        let rcArgument = "ExcessiveMethodLength10"
+                        let inputArguments = [currentPath, RuleCustomizationShort, rcArgument]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
+                    }
+                    
+                    it("should return empty dictionary if ruleCustommization argument contain more than one = symbol") {
+                        let rcArgument = "ExcessiveMethodLength=10=20"
+                        let inputArguments = [currentPath, RuleCustomizationShort, rcArgument]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
+                    }
+                    
+                    it("should return empty dictionary if ruleCustommizations type doesn't match possible types") {
+                        let rcArgument = "SomeErrorCaseCustomization=10"
+                        let inputArguments = [currentPath, RuleCustomizationShort, rcArgument]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
+                    }
+                    
+                    it("should return empty dictionary if argument for rule is not an integer") {
+                        let rcArgument = "SomeErrorCaseCustomization=1a0c"
+                        let inputArguments = [currentPath, RuleCustomizationShort, rcArgument]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
+                    }
+                    
+                }
+                
+                context("when arguments contain multiple customization rules") {
+                    
+                    it("should append multiple customization rules to ruleCustomizationOptions array") {
+                        let rcArgument1 = "ExcessiveMethodLength=10"
+                        let rcArgument2 = "ExcessiveClassLength=400"
+                        let inputArguments = [currentPath, RuleCustomizationLong, rcArgument1, RuleCustomizationShort, rcArgument2]
+                        forceProcessOptions(inputArguments)
+                        var rcArguments = [String]()
+                        for arg in optionsProcessor.factory.filterClassesOfType(RuleCustomizationOption().name) {
+                            rcArguments.append(arg.optionArgument)
+                        }
+                        let equal = ([rcArgument1, rcArgument2] == rcArguments)
+                        expect(equal).to(beTrue())
+                    }
+                    
+                    it("should return empty dictionary if rule customization types are repeated") {
+                        let rcArgument = "ExcessiveMethodLength=10"
+                        let inputArguments = [currentPath, RuleCustomizationLong, rcArgument, RuleCustomizationShort, rcArgument]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
+                    }
+                    
+                    it("should return empty dictionary if one of rulesCustomizations is not valid") {
+                        let rcArgument1 = "ExcessiveMethodLength=10"
+                        let rcArgument2 = "ExcessiveClassLength400"
+                        let inputArguments = [currentPath, RuleCustomizationLong, rcArgument1, RuleCustomizationShort, rcArgument2]
+                        let resultDictionary = forceProcessOptions(inputArguments)
+                        expect(resultDictionary).to(beEmpty())
+                    }
+                    
+                }
+                
+                context("when valid customizationRule is indicated") {
+                    
+                    it("should set customizationRules propery with dictionary(rule : complexity)") {
+                        let rcArgument1 = "ExcessiveMethodLength=10"
+                        let rcArgument2 = "ExcessiveClassLength=400"
+                        let inputArguments = [currentPath, RuleCustomizationLong, rcArgument1, RuleCustomizationShort, rcArgument2]
+                        forceProcessOptions(inputArguments)
+                        expect(optionsProcessor.factory.customizationRules).to(equal(["ExcessiveMethodLength" : 10, "ExcessiveClassLength" : 400]))
+                    }
+                    
+                    it("should set new customizationRules propery TooManyParameters") {
+                        let rcArgument1 = "ExcessiveParameterList=10"
+                        let inputArguments = [currentPath, RuleCustomizationLong, rcArgument1]
+                        forceProcessOptions(inputArguments)
+                        expect(optionsProcessor.factory.customizationRules).to(equal(["ExcessiveParameterList" : 10]))
+                    }
+                    
+                    it("should return empty dictionary if multiple rules of type TooManyParameters are indicated") {
+                        let rcArgument1 = "TooManyParameters=10"
+                        let inputArguments = [currentPath, RuleCustomizationLong, rcArgument1, RuleCustomizationShort, rcArgument1]
+                        expect(forceProcessOptions(inputArguments)).to(beEmpty())
+                    }
+                    
+                }
+                
+                it("should set default verbosity level to error when initialized") {
+                    let inputArguments = [currentPath]
+                    forceProcessOptions(inputArguments)
+                    expect(optionsProcessor.factory.verbosityLevel).to(equal(VerbosityLevel.Error))
+                }
+                
+                context("when verbosity level is inidicated") {
+                    
+                    it("should set optionsProcessor verbosityLevel property to indicated one") {
+                        let verbosityArgument = "info"
+                        let inputArguments = [currentPath, VerbosityLong, verbosityArgument]
+                        forceProcessOptions(inputArguments)
+                        expect(optionsProcessor.factory.verbosityLevel).to(equal(VerbosityLevel.Info))
+                    }
+                    
+                    it("should return empty dictionary if verbosity argument doesn't math possible arguments") {
+                        let verbosityArgument = "errorArgument"
+                        let inputArguments = [currentPath, VerbosityLong, verbosityArgument]
+                        expect(forceProcessOptions(inputArguments)).to(beEmpty())
+                    }
+                    
+                    it("should return empty dictionary if multiple verbosity options are indicated") {
+                        let verbosityArgument = "info"
+                        let inputArguments = [currentPath, VerbosityLong, verbosityArgument, VerbosityShort, verbosityArgument]
+                        expect(forceProcessOptions(inputArguments)).to(beEmpty())
+                    }
+                    
+                }
+                
+                context("when setDefaultValuesToResultDictionary is called") {
+                    
+                    it("should set default values only for keys that was not indicated") {
+                        var dictionary = [ResultDictionaryTypeKey : ["someType"]]
+                        optionsProcessor.setDefaultValuesToResultDictionary(&dictionary)
+                        expect(dictionary).to(equal([ResultDictionaryPathKey : [currentPath], ResultDictionaryTypeKey : ["someType"]]))
+                    }
+                    
+                    it("should set default values for dictionary") {
+                        var dictionary = Options()
+                        optionsProcessor.setDefaultValuesToResultDictionary(&dictionary)
+                        expect(dictionary).to(equal([ResultDictionaryPathKey : [currentPath], ResultDictionaryTypeKey : [DefaultExtensionType]]))
+                    }
+                    
+                    it("should not change values if they are already setted") {
+                        var dictionary = [ResultDictionaryPathKey : ["SomePath"], ResultDictionaryTypeKey : ["SomeExtension"]]
+                        optionsProcessor.setDefaultValuesToResultDictionary(&dictionary)
+                        expect(dictionary).to(equal([ResultDictionaryPathKey : ["SomePath"], ResultDictionaryTypeKey : ["SomeExtension"]]))
+                    }
+                    
+                    it("should set exclude paths from default excludesFile") {
+                        let pathToExcludesFile = MockFileManager().testFile("excludes", fileType: "yml")
+                        let pathToExcludesFileRootFolder = pathToExcludesFile.stringByReplacingOccurrencesOfString("/excludes.yml", withString: "")
+                        var dictionary = [ResultDictionaryPathKey : [pathToExcludesFileRootFolder]]
+                        optionsProcessor.setDefaultValuesToResultDictionary(&dictionary)
+                        let resultsArrayOfExcludes = ["file.txt".formattedExcludePath(pathToExcludesFileRootFolder), "path/to/file.txt".formattedExcludePath(pathToExcludesFileRootFolder), "folder".formattedExcludePath(pathToExcludesFileRootFolder), "path/to/folder".formattedExcludePath(pathToExcludesFileRootFolder)]
+                        expect(dictionary).to(equal([ResultDictionaryPathKey : [pathToExcludesFileRootFolder], ResultDictionaryTypeKey : [DefaultExtensionType], ResultDictionaryExcludesKey : resultsArrayOfExcludes]))
+                    }
+                    
+                }
             }
-            
-            context("when valid customizationRule is indicated") {
-                
-                it("should set customizationRules propery with dictionary(rule : complexity)") {
-                    let rcArgument1 = "ExcessiveMethodLength=10"
-                    let rcArgument2 = "ExcessiveClassLength=400"
-                    let inputArguments = [currentPath, RuleCustomizationLong, rcArgument1, RuleCustomizationShort, rcArgument2]
-                    optionsProcessor.processOptions(inputArguments)
-                    expect(optionsProcessor.factory.customizationRules).to(equal(["ExcessiveMethodLength" : 10, "ExcessiveClassLength" : 400]))
-                }
-                
-                it("should set new customizationRules propery TooManyParameters") {
-                    let rcArgument1 = "ExcessiveParameterList=10"
-                    let inputArguments = [currentPath, RuleCustomizationLong, rcArgument1]
-                    optionsProcessor.processOptions(inputArguments)
-                    expect(optionsProcessor.factory.customizationRules).to(equal(["ExcessiveParameterList" : 10]))
-                }
-                
-                it("should return empty dictionary if multiple rules of type TooManyParameters are indicated") {
-                    let rcArgument1 = "TooManyParameters=10"
-                    let inputArguments = [currentPath, RuleCustomizationLong, rcArgument1, RuleCustomizationShort, rcArgument1]
-                    expect(optionsProcessor.processOptions(inputArguments)).to(beEmpty())
-                }
-                
-            }
-            
-            it("should set default verbosity level to error when initialized") {
-                let inputArguments = [currentPath]
-                optionsProcessor.processOptions(inputArguments)
-                expect(optionsProcessor.factory.verbosityLevel).to(equal(VerbosityLevel.Error))
-            }
-            
-            context("when verbosity level is inidicated") {
-                
-                it("should set optionsProcessor verbosityLevel property to indicated one") {
-                    let verbosityArgument = "info"
-                    let inputArguments = [currentPath, VerbosityLong, verbosityArgument]
-                    optionsProcessor.processOptions(inputArguments)
-                    expect(optionsProcessor.factory.verbosityLevel).to(equal(VerbosityLevel.Info))
-                }
-                
-                it("should return empty dictionary if verbosity argument doesn't math possible arguments") {
-                    let verbosityArgument = "errorArgument"
-                    let inputArguments = [currentPath, VerbosityLong, verbosityArgument]
-                    expect(optionsProcessor.processOptions(inputArguments)).to(beEmpty())
-                }
-                
-                it("should return empty dictionary if multiple verbosity options are indicated") {
-                    let verbosityArgument = "info"
-                    let inputArguments = [currentPath, VerbosityLong, verbosityArgument, VerbosityShort, verbosityArgument]
-                    expect(optionsProcessor.processOptions(inputArguments)).to(beEmpty())
-                }
-                
-            }
-            
-            context("when setDefaultValuesToResultDictionary is called") {
-                
-                it("should set default values only for keys that was not indicated") {
-                    var dictionary = [ResultDictionaryTypeKey : ["someType"]]
-                    optionsProcessor.setDefaultValuesToResultDictionary(&dictionary)
-                    expect(dictionary).to(equal([ResultDictionaryPathKey : [currentPath], ResultDictionaryTypeKey : ["someType"]]))
-                }
-                
-                it("should set default values for dictionary") {
-                    var dictionary = Options()
-                    optionsProcessor.setDefaultValuesToResultDictionary(&dictionary)
-                    expect(dictionary).to(equal([ResultDictionaryPathKey : [currentPath], ResultDictionaryTypeKey : [DefaultExtensionType]]))
-                }
-                
-                it("should not change values if they are already setted") {
-                    var dictionary = [ResultDictionaryPathKey : ["SomePath"], ResultDictionaryTypeKey : ["SomeExtension"]]
-                    optionsProcessor.setDefaultValuesToResultDictionary(&dictionary)
-                    expect(dictionary).to(equal([ResultDictionaryPathKey : ["SomePath"], ResultDictionaryTypeKey : ["SomeExtension"]]))
-                }
-                
-                it("should set exclude paths from default excludesFile") {
-                    let pathToExcludesFile = MockFileManager().testFile("excludes", fileType: "yml")
-                    let pathToExcludesFileRootFolder = pathToExcludesFile.stringByReplacingOccurrencesOfString("/excludes.yml", withString: "")
-                    var dictionary = [ResultDictionaryPathKey : [pathToExcludesFileRootFolder]]
-                    optionsProcessor.setDefaultValuesToResultDictionary(&dictionary)
-                    let resultsArrayOfExcludes = ["file.txt".formattedExcludePath(pathToExcludesFileRootFolder), "path/to/file.txt".formattedExcludePath(pathToExcludesFileRootFolder), "folder".formattedExcludePath(pathToExcludesFileRootFolder), "path/to/folder".formattedExcludePath(pathToExcludesFileRootFolder)]
-                    expect(dictionary).to(equal([ResultDictionaryPathKey : [pathToExcludesFileRootFolder], ResultDictionaryTypeKey : [DefaultExtensionType], ResultDictionaryExcludesKey : resultsArrayOfExcludes]))
-                }
-                
-            }
-            
         }
     }
 }

--- a/TaylorFrameworkTests/TaylorTests/ReportGeneratorTests.swift
+++ b/TaylorFrameworkTests/TaylorTests/ReportGeneratorTests.swift
@@ -19,7 +19,7 @@ class ReportGeneratorTests : QuickSpec {
             var reportGenerator: ReportGenerator!
             
             beforeEach {
-                reportGenerator = ReportGenerator(arguments: Arguments(), printer: Printer(verbosityLevel: .Info))
+                reportGenerator = ReportGenerator(arguments: try! Arguments(), printer: Printer(verbosityLevel: .Info))
             }
             
             afterEach {


### PR DESCRIPTION
```
Handle the case when Taylor is invoked with invalid arguments:
* Remove force try inside `processArguments()` that was leading to
imminent crash and unclear error message.
* If an invalid parameter has been sent print error message and
prompt the user to play Pacman.
```
