### PR TITLE
Round running time to two decimal places

### DIFF
--- a/TaylorFramework/Taylor/Taylor.swift
+++ b/TaylorFramework/Taylor/Taylor.swift
@@ -54,7 +54,8 @@ public struct Taylor {
         let timer = Timer()
         timer.start()
         generateReportOnPath(rootPath, arguments: arguments, printer: printer)
-        printer.printInfo("Running time: \(timer.stop())")
+        let time = String(format: "%.2f", timer.stop())
+        printer.printInfo("Running time: \(time) seconds")
     }
     
     func generateReportOnPath(path: Path, arguments: Arguments, printer: Printer) {


### PR DESCRIPTION
Running time will be rounded to two decimal places. Instead of getting `Running time: 0.340104997158051`, now we'll have `Running time: 0.34 seconds`.  
It's cleaner. And better looking. 💄 
